### PR TITLE
로그아웃 api 구현

### DIFF
--- a/src/main/java/sparta/com/sappun/domain/user/dto/response/UserLogoutRes.java
+++ b/src/main/java/sparta/com/sappun/domain/user/dto/response/UserLogoutRes.java
@@ -1,0 +1,6 @@
+package sparta.com.sappun.domain.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties
+public class UserLogoutRes {}

--- a/src/main/java/sparta/com/sappun/global/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/sparta/com/sappun/global/jwt/JwtAuthorizationFilter.java
@@ -57,7 +57,9 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         // access token 검증
         TokenValidator.checkValidAccessToken(jwtUtil.validateToken(accessToken));
 
-        // TODO: 로그아웃된 access token 인지 확인
+        // 로그아웃된 access token 인지 확인
+        TokenValidator.checkLoginRequired(redisUtil.hasKey(accessToken));
+        log.info("로그아웃되지 않은 accessToken");
 
         // 유효한 access token 이면 인증 처리
         if (!jwtUtil.isTokenExpired(accessToken)) {

--- a/src/main/java/sparta/com/sappun/global/jwt/JwtUtil.java
+++ b/src/main/java/sparta/com/sappun/global/jwt/JwtUtil.java
@@ -107,4 +107,19 @@ public class JwtUtil {
     public String getUserIdFromToken(String token) {
         return jwtParser.parseClaimsJws(token).getBody().getSubject();
     }
+
+    /** 액세스 토큰의 남은 유효 시간 확인 */
+    public int getExpiration(String accessToken) {
+        Date expiration =
+                Jwts.parserBuilder()
+                        .setSigningKey(key)
+                        .build()
+                        .parseClaimsJws(accessToken)
+                        .getBody()
+                        .getExpiration();
+
+        long now = new Date().getTime(); // 현재 시간
+
+        return (int) ((expiration.getTime() - now) / (60 * 1000));
+    }
 }

--- a/src/test/java/sparta/com/sappun/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/sparta/com/sappun/domain/user/controller/UserControllerTest.java
@@ -88,4 +88,26 @@ class UserControllerTest extends BaseMvcTest implements UserTest {
                 .andDo(print())
                 .andExpect(status().isOk());
     }
+
+    @Test
+    @DisplayName("logout 테스트")
+    void logoutTest() throws Exception {
+        // given
+        String accessToken = "accessToken";
+        String refreshToken = "refreshToken";
+
+        // when
+        when(jwtUtil.getTokenWithoutBearer(any())).thenReturn(accessToken);
+        when(jwtUtil.getTokenWithoutBearer(any())).thenReturn(refreshToken);
+
+        // then
+        mockMvc
+                .perform(
+                        post("/api/users/logout")
+                                .header("Authorization", "Bearer " + accessToken)
+                                .header("Refresh-Token", "Bearer " + refreshToken)
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
 }


### PR DESCRIPTION
## 개요
로그아웃 api를 구현합니다.

## 작업사항
- 로그아웃 api 구현
- controller 테스트 추가

## 관련 이슈
- 로그아웃 시 클라이언트에서 access token과 refresh token을 모두 보내준다고 가정하고 구현했습니다.
- 잘못해서 login 브랜치에 커밋했습니다..
- close #14 
