### PR TITLE
user 도메인 관련 수정, BoardServiceMapper 오류 수정

### DIFF
--- a/src/main/java/sparta/com/sappun/domain/ReportBoard/service/ReportBoardService.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportBoard/service/ReportBoardService.java
@@ -11,6 +11,7 @@ import sparta.com.sappun.domain.board.entity.Board;
 import sparta.com.sappun.domain.board.repository.BoardRepository;
 import sparta.com.sappun.domain.user.entity.User;
 import sparta.com.sappun.domain.user.repository.UserRepository;
+import sparta.com.sappun.global.validator.BoardValidator;
 import sparta.com.sappun.global.validator.UserValidator;
 
 @Service
@@ -24,7 +25,7 @@ public class ReportBoardService {
     @Transactional
     public ReportBoardRes reportBoardRes(Long boardId, ReportBoardReq req) {
         Board board = boardRepository.findById(boardId);
-        // BoardValidator.validate(board);
+        BoardValidator.validate(board);
         User user = userRepository.findById(req.getUserId());
         UserValidator.validate(user);
         ReportBoard reportBoard =

--- a/src/main/java/sparta/com/sappun/domain/ReportComment/controller/ReportCommentController.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportComment/controller/ReportCommentController.java
@@ -1,4 +1,4 @@
-package sparta.com.sappun.domain.ReportComment.contorller;
+package sparta.com.sappun.domain.ReportComment.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/sparta/com/sappun/domain/ReportComment/service/ReportCommentService.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportComment/service/ReportCommentService.java
@@ -11,6 +11,7 @@ import sparta.com.sappun.domain.comment.entity.Comment;
 import sparta.com.sappun.domain.comment.repository.CommentRepository;
 import sparta.com.sappun.domain.user.entity.User;
 import sparta.com.sappun.domain.user.repository.UserRepository;
+import sparta.com.sappun.global.validator.CommentValidator;
 import sparta.com.sappun.global.validator.UserValidator;
 
 @Service
@@ -24,7 +25,7 @@ public class ReportCommentService {
     @Transactional
     public ReportCommentRes reportCommentRes(Long commentId, ReportCommentReq req) {
         Comment comment = commentRepository.findById(commentId);
-        // CommentValidator.validate(comment);
+        CommentValidator.validate(comment);
         User user = userRepository.findById(req.getUserId());
         UserValidator.validate(user);
         ReportComment reportComment =

--- a/src/main/java/sparta/com/sappun/domain/board/service/BoardService.java
+++ b/src/main/java/sparta/com/sappun/domain/board/service/BoardService.java
@@ -52,8 +52,7 @@ public class BoardService {
 
     @Transactional
     public BoardSaveRes saveBoard(BoardSaveReq boardSaveReq) {
-        User user = userRepository.findById(boardSaveReq.getUserId());
-        UserValidator.validate(user);
+        User user = getUserById(boardSaveReq.getUserId());
 
         return BoardServiceMapper.INSTANCE.toBoardSavaRes(
                 boardRepository.save(
@@ -73,5 +72,11 @@ public class BoardService {
         Board board = boardRepository.findById(boardId);
         BoardValidator.validate(board);
         return board;
+    }
+
+    private User getUserById(Long userId) {
+        User user = userRepository.findById(userId);
+        UserValidator.validate(user);
+        return user;
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/board/service/BoardService.java
+++ b/src/main/java/sparta/com/sappun/domain/board/service/BoardService.java
@@ -54,7 +54,7 @@ public class BoardService {
     public BoardSaveRes saveBoard(BoardSaveReq boardSaveReq) {
         User user = getUserById(boardSaveReq.getUserId());
 
-        return BoardServiceMapper.INSTANCE.toBoardSavaRes(
+        return BoardServiceMapper.INSTANCE.toBoardSaveRes(
                 boardRepository.save(
                         Board.builder()
                                 .title(boardSaveReq.getTitle())

--- a/src/main/java/sparta/com/sappun/domain/board/service/BoardServiceMapper.java
+++ b/src/main/java/sparta/com/sappun/domain/board/service/BoardServiceMapper.java
@@ -7,6 +7,8 @@ import org.mapstruct.factory.Mappers;
 import sparta.com.sappun.domain.board.dto.response.BoardGetRes;
 import sparta.com.sappun.domain.board.dto.response.BoardSaveRes;
 import sparta.com.sappun.domain.board.entity.Board;
+import sparta.com.sappun.domain.comment.dto.response.CommentGetRes;
+import sparta.com.sappun.domain.comment.entity.Comment;
 
 @Mapper
 public interface BoardServiceMapper {
@@ -20,5 +22,8 @@ public interface BoardServiceMapper {
     List<BoardGetRes> toBoardBestListGetRes(List<Board> boardList);
 
     @Mapping(source = "user.nickname", target = "nickname")
-    BoardSaveRes toBoardSavaRes(Board board);
+    BoardSaveRes toBoardSaveRes(Board board);
+
+    @Mapping(source = "user.nickname", target = "nickname")
+    CommentGetRes toCommentGetRes(Comment comment);
 }

--- a/src/main/java/sparta/com/sappun/domain/comment/controller/CommentController.java
+++ b/src/main/java/sparta/com/sappun/domain/comment/controller/CommentController.java
@@ -6,7 +6,6 @@ import org.springframework.web.bind.annotation.*;
 import sparta.com.sappun.domain.comment.dto.request.CommentSaveReq;
 import sparta.com.sappun.domain.comment.dto.response.CommentSaveRes;
 import sparta.com.sappun.domain.comment.service.CommentService;
-import sparta.com.sappun.domain.user.service.UserService;
 import sparta.com.sappun.global.response.CommonResponse;
 import sparta.com.sappun.global.security.UserDetailsImpl;
 
@@ -16,7 +15,6 @@ import sparta.com.sappun.global.security.UserDetailsImpl;
 public class CommentController {
 
     private final CommentService commentService;
-    private final UserService userService;
 
     @PostMapping
     public CommonResponse<CommentSaveRes> saveComment(

--- a/src/main/java/sparta/com/sappun/domain/comment/service/CommentService.java
+++ b/src/main/java/sparta/com/sappun/domain/comment/service/CommentService.java
@@ -21,8 +21,7 @@ public class CommentService {
     @Transactional
     public CommentSaveRes saveComment(CommentSaveReq commentSaveReq) {
         // 보드 아이디 조회 로직 구현 필요
-        User user = userRepository.findById(commentSaveReq.getUserId());
-        UserValidator.validate(user);
+        User user = getUserById(commentSaveReq.getUserId());
 
         return CommentServiceMapper.INSTANCE.toCommentSaveRes(
                 commentRepository.save(
@@ -31,5 +30,11 @@ public class CommentService {
                                 .fileUrl(commentSaveReq.getFileUrl())
                                 .user(user)
                                 .build()));
+    }
+
+    private User getUserById(Long userId) {
+        User user = userRepository.findById(userId);
+        UserValidator.validate(user);
+        return user;
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/comment/service/CommentService.java
+++ b/src/main/java/sparta/com/sappun/domain/comment/service/CommentService.java
@@ -70,8 +70,7 @@ public class CommentService {
         User user = getUserById(req.getUserId());
 
         // 사용자가 작성자 또는 관리자인지 확인
-        CommentValidator.checkCommentUser(comment.getUser().getId(), user.getId());
-        // TODO: 관리자 인지 확인 로직 필요
+        CommentValidator.checkCommentUser(comment.getUser(), user);
 
         // 댓글 삭제 로직
         commentRepository.delete(comment);

--- a/src/main/java/sparta/com/sappun/domain/user/controller/UserController.java
+++ b/src/main/java/sparta/com/sappun/domain/user/controller/UserController.java
@@ -89,7 +89,7 @@ public class UserController {
     // 프로필 수정
     @PatchMapping("/profile")
     public CommonResponse<UserProfileUpdateRes> updateProfile(
-            @RequestBody UserProfileUpdateReq req,
+            @RequestBody @Valid UserProfileUpdateReq req,
             @AuthenticationPrincipal UserDetailsImpl userDetails) { // TODO: 프로필 사진 입력받기
         req.setId(userDetails.getUser().getId());
         return CommonResponse.success(userService.updateProfile(req));
@@ -98,7 +98,7 @@ public class UserController {
     // 비밀번호 수정
     @PatchMapping("/profile/password")
     public CommonResponse<UserPasswordUpdateRes> updatePassword(
-            @RequestBody UserPasswordUpdateReq req,
+            @RequestBody @Valid UserPasswordUpdateReq req,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         req.setId(userDetails.getUser().getId());
         return CommonResponse.success(userService.updatePassword(req));
@@ -106,13 +106,15 @@ public class UserController {
 
     // 아이디 중복 확인
     @PostMapping("/username")
-    public CommonResponse<UsernameVerifyRes> verifyUsername(@RequestBody UsernameVerifyReq req) {
+    public CommonResponse<UsernameVerifyRes> verifyUsername(
+            @RequestBody @Valid UsernameVerifyReq req) {
         return CommonResponse.success(userService.verifyUsername(req));
     }
 
     // 닉네임 중복확인
     @PostMapping("/nickname")
-    public CommonResponse<NicknameVerifyRes> verifyNickname(@RequestBody NicknameVerifyReq req) {
+    public CommonResponse<NicknameVerifyRes> verifyNickname(
+            @RequestBody @Valid NicknameVerifyReq req) {
         return CommonResponse.success(userService.verifyNickname(req));
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/user/dto/request/NicknameVerifyReq.java
+++ b/src/main/java/sparta/com/sappun/domain/user/dto/request/NicknameVerifyReq.java
@@ -8,8 +8,8 @@ import lombok.*;
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NicknameVerifyReq {
-    @Size(min = 4, max = 10)
-    @Pattern(regexp = "^[a-zA-Z0-9]*$")
+    @Size(min = 2, max = 10)
+    @Pattern(regexp = "^[가-힣a-zA-Z0-9]*$")
     private String nickname;
 
     @Builder

--- a/src/main/java/sparta/com/sappun/domain/user/dto/request/UserLoginReq.java
+++ b/src/main/java/sparta/com/sappun/domain/user/dto/request/UserLoginReq.java
@@ -15,7 +15,7 @@ public class UserLoginReq {
     private String password;
 
     @Builder
-    public UserLoginReq(String username, String password) {
+    private UserLoginReq(String username, String password) {
         this.username = username;
         this.password = password;
     }

--- a/src/main/java/sparta/com/sappun/domain/user/dto/request/UserPasswordUpdateReq.java
+++ b/src/main/java/sparta/com/sappun/domain/user/dto/request/UserPasswordUpdateReq.java
@@ -31,7 +31,7 @@ public class UserPasswordUpdateReq {
     private String confirmPassword;
 
     @Builder
-    public UserPasswordUpdateReq(String prePassword, String newPassword, String confirmPassword) {
+    private UserPasswordUpdateReq(String prePassword, String newPassword, String confirmPassword) {
         this.prePassword = prePassword;
         this.newPassword = newPassword;
         this.confirmPassword = confirmPassword;

--- a/src/main/java/sparta/com/sappun/domain/user/dto/request/UserProfileUpdateReq.java
+++ b/src/main/java/sparta/com/sappun/domain/user/dto/request/UserProfileUpdateReq.java
@@ -24,7 +24,7 @@ public class UserProfileUpdateReq {
     private String profileUrl;
 
     @Builder
-    public UserProfileUpdateReq(String username, String nickname, String profileUrl) {
+    private UserProfileUpdateReq(String username, String nickname, String profileUrl) {
         this.username = username;
         this.nickname = nickname;
         this.profileUrl = profileUrl;

--- a/src/main/java/sparta/com/sappun/domain/user/service/UserService.java
+++ b/src/main/java/sparta/com/sappun/domain/user/service/UserService.java
@@ -50,8 +50,7 @@ public class UserService {
 
     @Transactional
     public UserDeleteRes deleteUser(Long id) {
-        User user = userRepository.findById(id);
-        UserValidator.validate(user); // 사용자가 존재하는지 확인
+        User user = getUserById(id); // 사용자가 존재하는지 확인
 
         // TODO: 회원 탈퇴 시 회원의 게시글과 댓글, 좋아요 등의 처리를 어떻게 할 것인지 정하기
 
@@ -63,16 +62,14 @@ public class UserService {
     // 프로필 조회
     @Transactional(readOnly = true)
     public UserProfileRes getProfile(Long userId) {
-        User user = userRepository.findById(userId);
-        UserValidator.validate(user); // 사용자가 존재하는지 확인
-        return UserServiceMapper.INSTANCE.toUserProfileRes(user);
+        return UserServiceMapper.INSTANCE.toUserProfileRes(getUserById(userId));
     }
 
     // 프로필 수정
     @Transactional
     public UserProfileUpdateRes updateProfile(UserProfileUpdateReq req) {
-        User user = userRepository.findById(req.getId());
-        UserValidator.validate(user); // 사용자가 존재하는지 확인
+        User user = getUserById(req.getId()); // 사용자가 존재하는지 확인
+
         //        UserValidator.checkDuplicatedUsername(
         //                userRepository.existsByUsername(req.getUsername())); // username 중복확인
         //        UserValidator.checkDuplicatedNickname(
@@ -87,8 +84,8 @@ public class UserService {
 
     // 비밀번호 수정
     public UserPasswordUpdateRes updatePassword(UserPasswordUpdateReq req) {
-        User user = userRepository.findById(req.getId());
-        UserValidator.validate(user); // 사용자가 존재하는지 확인
+        User user = getUserById(req.getId()); // 사용자가 존재하는지 확인
+
         UserValidator.checkEqualsPassword(
                 passwordEncoder.matches(
                         req.getPrePassword(), user.getPassword())); // 저장소 내의 비밀번호랑 req의 prepassword가 일치하는지 확인
@@ -114,5 +111,11 @@ public class UserService {
         return NicknameVerifyRes.builder()
                 .isDuplicated(userRepository.existsByNickname(req.getNickname()))
                 .build(); // nickname 중복확인
+    }
+
+    private User getUserById(Long userId) {
+        User user = userRepository.findById(userId);
+        UserValidator.validate(user);
+        return user;
     }
 }

--- a/src/main/java/sparta/com/sappun/global/validator/CommentValidator.java
+++ b/src/main/java/sparta/com/sappun/global/validator/CommentValidator.java
@@ -4,6 +4,8 @@ import static sparta.com.sappun.global.response.ResultCode.ACCESS_DENY;
 import static sparta.com.sappun.global.response.ResultCode.NOT_FOUND_COMMENT;
 
 import sparta.com.sappun.domain.comment.entity.Comment;
+import sparta.com.sappun.domain.user.entity.Role;
+import sparta.com.sappun.domain.user.entity.User;
 import sparta.com.sappun.global.exception.GlobalException;
 
 public class CommentValidator {
@@ -14,8 +16,15 @@ public class CommentValidator {
         }
     }
 
-    public static void checkCommentUser(Long id, Long userId) {
+    public static void checkCommentUser(Long id, Long userId) { // 접근자와 작성자가 동일한지 확인
         if (!id.equals(userId)) {
+            throw new GlobalException(ACCESS_DENY);
+        }
+    }
+
+    public static void checkCommentUser(User accessor, User author) {
+        if (!accessor.getId().equals(author.getId())
+                && accessor.getRole() != Role.ADMIN) { // 접근자와 작성자가 동일하거나 접근자가 관리자인지 확인
             throw new GlobalException(ACCESS_DENY);
         }
     }


### PR DESCRIPTION
## 개요
user 도메인 및 BoardServiceMapper 오류를 수정합니다

## 작업사항
- 다른 도메인에 getUserById 메서드를 추출
- user 도메인의 validation 관련 수정
- public -> private 수정
- comment의 관리자 확인 로직 추가
- BoardServiceMapper 오류 수정
(Board 내부의 Comment를 CommentGetRes로 변환하는 과정에서 BoardMapper는 CommentMapper를 가져올 수 없어서 생긴 오류로 보여 수정했습니다. 그런데 테스트는 못해봐서 null값이 떴던 상율님께서 이후에 테스트 같이 해주시면 감사하겠습니다!)

## 관련 이슈
- close #47 
