### PR TITLE
사용자 도메인에 이메일 추가

### DIFF
--- a/src/main/java/sparta/com/sappun/domain/user/dto/request/UserSignupReq.java
+++ b/src/main/java/sparta/com/sappun/domain/user/dto/request/UserSignupReq.java
@@ -21,6 +21,9 @@ public class UserSignupReq {
     @Pattern(regexp = "^[가-힣a-zA-Z0-9]*$")
     private String nickname;
 
+    @Pattern(regexp = "\\w+@\\w+\\.\\w+(\\.\\w+)?")
+    private String email;
+
     @Size(min = 6, max = 15)
     @Pattern(regexp = "^(?=.*[a-z])(?=.*\\d)(?=.*[@$!%#?&])[A-Za-z\\d@$!%*#?&]*$")
     // 영어 소문자, 숫자, 특수문자를 각 하나씩 필수로 포함
@@ -29,9 +32,11 @@ public class UserSignupReq {
     private String confirmPassword;
 
     @Builder
-    private UserSignupReq(String username, String nickname, String password, String confirmPassword) {
+    private UserSignupReq(
+            String username, String nickname, String email, String password, String confirmPassword) {
         this.username = username;
         this.nickname = nickname;
+        this.email = email;
         this.password = password;
         this.confirmPassword = confirmPassword;
     }

--- a/src/main/java/sparta/com/sappun/domain/user/dto/response/UserProfileRes.java
+++ b/src/main/java/sparta/com/sappun/domain/user/dto/response/UserProfileRes.java
@@ -9,14 +9,17 @@ public class UserProfileRes {
     private Long id;
     private String username;
     private String nickname;
+    private String email;
     private String profileUrl;
     // private Integer score; // 좋아요(+1) + 신고(-1)
 
     @Builder
-    private UserProfileRes(Long id, String username, String nickname, String profileUrl) {
+    private UserProfileRes(
+            Long id, String username, String nickname, String email, String profileUrl) {
         this.id = id;
         this.username = username;
         this.nickname = nickname;
+        this.email = email;
         this.profileUrl = profileUrl;
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/user/dto/response/UserProfileUpdateRes.java
+++ b/src/main/java/sparta/com/sappun/domain/user/dto/response/UserProfileUpdateRes.java
@@ -12,14 +12,17 @@ public class UserProfileUpdateRes {
     private Long id;
     private String username;
     private String nickname;
+    private String email;
     private String profileUrl;
     // private Integer score; // 좋아요(+1) + 신고(-1)
 
     @Builder
-    private UserProfileUpdateRes(Long id, String username, String nickname, String profileUrl) {
+    private UserProfileUpdateRes(
+            Long id, String username, String nickname, String email, String profileUrl) {
         this.id = id;
         this.username = username;
         this.nickname = nickname;
+        this.email = email;
         this.profileUrl = profileUrl;
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/user/repository/UserRepository.java
+++ b/src/main/java/sparta/com/sappun/domain/user/repository/UserRepository.java
@@ -16,4 +16,6 @@ public interface UserRepository {
     Boolean existsByUsername(String username);
 
     Boolean existsByNickname(String nickname);
+
+    Boolean existsByEmail(String email);
 }

--- a/src/main/java/sparta/com/sappun/domain/user/service/UserService.java
+++ b/src/main/java/sparta/com/sappun/domain/user/service/UserService.java
@@ -21,7 +21,9 @@ public class UserService {
 
     @Transactional
     public UserSignupRes signup(UserSignupReq req) {
-        UserValidator.validate(req); // 재확인 비밀번호가 일치하는지 확인 (중복검사는 api를 따로 분리했으므로 추가하지 않음)
+        UserValidator.validate(req);
+
+        UserValidator.checkEmail(userRepository.existsByEmail(req.getEmail()));
 
         // TODO: 프로필 사진 관련 로직 추가
 
@@ -29,6 +31,7 @@ public class UserService {
                 User.builder()
                         .username(req.getUsername())
                         .nickname(req.getNickname())
+                        .email(req.getEmail())
                         .password(passwordEncoder.encode(req.getPassword()))
                         .role(Role.USER)
                         .build());

--- a/src/main/java/sparta/com/sappun/global/response/ResultCode.java
+++ b/src/main/java/sparta/com/sappun/global/response/ResultCode.java
@@ -20,6 +20,7 @@ public enum ResultCode {
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     DUPLICATED_USERNAME(HttpStatus.CONFLICT, "중복된 아이디 입니다."),
     DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "중복된 닉네임 입니다."),
+    DUPLICATED_EMAIL(HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
     DIFFERENT_PASSWORD(HttpStatus.CONFLICT, "비밀번호가 일치하지 않습니다."),
 
     // 보드

--- a/src/main/java/sparta/com/sappun/global/validator/UserValidator.java
+++ b/src/main/java/sparta/com/sappun/global/validator/UserValidator.java
@@ -26,6 +26,12 @@ public class UserValidator {
         }
     }
 
+    public static void checkEmail(boolean isDuplicated) {
+        if (isDuplicated) {
+            throw new GlobalException(DUPLICATED_EMAIL);
+        }
+    }
+
     private static boolean checkConfirmPassword(String password1, String password2) {
         return Objects.equals(password1, password2);
     }

--- a/src/test/java/sparta/com/sappun/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/sparta/com/sappun/domain/user/controller/UserControllerTest.java
@@ -39,6 +39,7 @@ class UserControllerTest extends BaseMvcTest implements UserTest {
                 UserSignupReq.builder()
                         .username(TEST_USER_USERNAME)
                         .nickname(TEST_USER_NICKNAME)
+                        .email(TEST_USER_EMAIL)
                         .password(TEST_USER_PASSWORD)
                         .confirmPassword(TEST_USER_PASSWORD)
                         .build();
@@ -106,8 +107,8 @@ class UserControllerTest extends BaseMvcTest implements UserTest {
         mockMvc
                 .perform(
                         post("/api/users/logout")
-                                .header("Authorization", "Bearer " + accessToken)
-                                .header("Refresh-Token", "Bearer " + refreshToken)
+                                .header("AccessToken", "Bearer " + accessToken)
+                                .header("RefreshToken", "Bearer " + refreshToken)
                                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk());

--- a/src/test/java/sparta/com/sappun/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/sparta/com/sappun/domain/user/repository/UserRepositoryTest.java
@@ -72,4 +72,43 @@ class UserRepositoryTest implements UserTest {
         // then
         assertNull(findUser);
     }
+
+    @Test
+    @DisplayName("existsByUsername 테스트")
+    void existsByUsernameTest() {
+        // given
+        User user = userRepository.save(TEST_USER);
+
+        // when
+        Boolean isFound = userRepository.existsByUsername(user.getUsername());
+
+        // then
+        assertTrue(isFound);
+    }
+
+    @Test
+    @DisplayName("existsByNickname 테스트")
+    void existsByNicknameTest() {
+        // given
+        User user = userRepository.save(TEST_USER);
+
+        // when
+        Boolean isFound = userRepository.existsByNickname(user.getNickname());
+
+        // then
+        assertTrue(isFound);
+    }
+
+    @Test
+    @DisplayName("existsByEmail 테스트")
+    void existsByEmailTest() {
+        // given
+        User user = userRepository.save(TEST_USER);
+
+        // when
+        Boolean isFound = userRepository.existsByEmail(user.getEmail());
+
+        // then
+        assertTrue(isFound);
+    }
 }

--- a/src/test/java/sparta/com/sappun/domain/user/service/UserServiceTest.java
+++ b/src/test/java/sparta/com/sappun/domain/user/service/UserServiceTest.java
@@ -43,6 +43,7 @@ class UserServiceTest implements UserTest {
                 UserSignupReq.builder()
                         .username(TEST_USER_USERNAME)
                         .nickname(TEST_USER_NICKNAME)
+                        .email(TEST_USER_EMAIL)
                         .password(TEST_USER_PASSWORD)
                         .confirmPassword(TEST_USER_PASSWORD)
                         .build();
@@ -55,6 +56,7 @@ class UserServiceTest implements UserTest {
         verify(passwordEncoder).encode(TEST_USER_PASSWORD);
         assertEquals(TEST_USER_USERNAME, argumentCaptor.getValue().getUsername());
         assertEquals(TEST_USER_NICKNAME, argumentCaptor.getValue().getNickname());
+        assertEquals(TEST_USER_EMAIL, argumentCaptor.getValue().getEmail());
     }
 
     @Test
@@ -65,6 +67,7 @@ class UserServiceTest implements UserTest {
                 UserSignupReq.builder()
                         .username(TEST_USER_USERNAME)
                         .nickname(TEST_USER_NICKNAME)
+                        .email(TEST_USER_EMAIL)
                         .password(TEST_USER_PASSWORD)
                         .confirmPassword("wrongPassword")
                         .build();

--- a/src/test/java/sparta/com/sappun/test/UserTest.java
+++ b/src/test/java/sparta/com/sappun/test/UserTest.java
@@ -10,11 +10,14 @@ public interface UserTest {
     String TEST_USER_NICKNAME = "nickname";
     String TEST_USER_PASSWORD = "abc123@";
 
+    String TEST_USER_EMAIL = "aaa@aa.aa";
+
     User TEST_USER =
             User.builder()
                     .username(TEST_USER_USERNAME)
                     .nickname(TEST_USER_NICKNAME)
                     .password(TEST_USER_PASSWORD)
+                    .email(TEST_USER_EMAIL)
                     .role(Role.USER)
                     .build();
 }


### PR DESCRIPTION
## 개요
사용자 도메인에 이메일 필드를 추가합니다.

## 작업사항
- 회원가입 시 이메일도 입력받아 중복 확인
- 프로필 조회, 수정 시 이메일 response에 추가
- 관련 테스트 코드 수정

## 관련 이슈
- close #60 
