### PR TITLE
관리자의 게시글, 댓글 신고 취소 기능 추가

### DIFF
--- a/src/main/java/sparta/com/sappun/domain/ReportBoard/contorller/ReportBoardController.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportBoard/contorller/ReportBoardController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import sparta.com.sappun.domain.ReportBoard.dto.request.ReportBoardReq;
+import sparta.com.sappun.domain.ReportBoard.dto.response.DeleteReportBoardRes;
 import sparta.com.sappun.domain.ReportBoard.dto.response.ReportBoardRes;
 import sparta.com.sappun.domain.ReportBoard.service.ReportBoardService;
 import sparta.com.sappun.global.security.UserDetailsImpl;
@@ -25,5 +26,11 @@ public class ReportBoardController {
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         req.setUserId(userDetails.getUser().getId());
         return ResponseEntity.ok(reportBoardService.reportBoardRes(boardId, req));
+    }
+
+    @DeleteMapping("/{boardId}/report") // 필터에서 관리자만 접근하도록 막기
+    public ResponseEntity<DeleteReportBoardRes> deleteReportedBoard(
+        @PathVariable Long boardId) {
+        return ResponseEntity.ok(reportBoardService.deleteReportBoard(boardId));
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/ReportBoard/contorller/ReportBoardController.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportBoard/contorller/ReportBoardController.java
@@ -25,12 +25,11 @@ public class ReportBoardController {
             @RequestBody @Valid ReportBoardReq req,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         req.setUserId(userDetails.getUser().getId());
-        return ResponseEntity.ok(reportBoardService.reportBoardRes(boardId, req));
+        return ResponseEntity.ok(reportBoardService.reportBoard(boardId, req));
     }
 
     @DeleteMapping("/{boardId}/report") // 필터에서 관리자만 접근하도록 막기
-    public ResponseEntity<DeleteReportBoardRes> deleteReportedBoard(
-        @PathVariable Long boardId) {
+    public ResponseEntity<DeleteReportBoardRes> deleteReportedBoard(@PathVariable Long boardId) {
         return ResponseEntity.ok(reportBoardService.deleteReportBoard(boardId));
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/ReportBoard/dto/request/ReportBoardReq.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportBoard/dto/request/ReportBoardReq.java
@@ -8,13 +8,11 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReportBoardReq {
 
-    private Long reportBoardId;
     @NotBlank private String reason;
     private Long userId;
 
     @Builder
-    private ReportBoardReq(Long reportBoardId, String reason) {
-        this.reportBoardId = reportBoardId;
+    private ReportBoardReq(String reason) {
         this.reason = reason;
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/ReportBoard/dto/response/DeleteReportBoardRes.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportBoard/dto/response/DeleteReportBoardRes.java
@@ -3,6 +3,4 @@ package sparta.com.sappun.domain.ReportBoard.dto.response;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties
-public class DeleteReportBoardRes {
-
-}
+public class DeleteReportBoardRes {}

--- a/src/main/java/sparta/com/sappun/domain/ReportBoard/dto/response/DeleteReportBoardRes.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportBoard/dto/response/DeleteReportBoardRes.java
@@ -1,0 +1,8 @@
+package sparta.com.sappun.domain.ReportBoard.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties
+public class DeleteReportBoardRes {
+
+}

--- a/src/main/java/sparta/com/sappun/domain/ReportBoard/repository/ReportBoardRepository.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportBoard/repository/ReportBoardRepository.java
@@ -1,9 +1,19 @@
 package sparta.com.sappun.domain.ReportBoard.repository;
 
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.RepositoryDefinition;
 import sparta.com.sappun.domain.ReportBoard.entity.ReportBoard;
+import sparta.com.sappun.domain.board.entity.Board;
+import sparta.com.sappun.domain.user.entity.User;
 
 @RepositoryDefinition(domainClass = ReportBoard.class, idClass = Long.class)
 public interface ReportBoardRepository {
     ReportBoard save(ReportBoard reportBoard);
+
+    @Query(value = "select r.user FROM ReportBoard r WHERE r.board = :board")
+    List<User> selectUserByBoard(Board board);
+
+    @Query(value = "delete from ReportBoard r where r.board = :board")
+    void clearReportBoardByBoard(Board board);
 }

--- a/src/main/java/sparta/com/sappun/domain/ReportBoard/repository/ReportBoardRepository.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportBoard/repository/ReportBoardRepository.java
@@ -1,6 +1,7 @@
 package sparta.com.sappun.domain.ReportBoard.repository;
 
 import java.util.List;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.RepositoryDefinition;
 import sparta.com.sappun.domain.ReportBoard.entity.ReportBoard;
@@ -14,6 +15,7 @@ public interface ReportBoardRepository {
     @Query(value = "select r.user FROM ReportBoard r WHERE r.board = :board")
     List<User> selectUserByBoard(Board board);
 
+    @Modifying // select 외의 쿼리를 사용하기 위해서 필요함
     @Query(value = "delete from ReportBoard r where r.board = :board")
     void clearReportBoardByBoard(Board board);
 }

--- a/src/main/java/sparta/com/sappun/domain/ReportBoard/service/ReportBoardService.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportBoard/service/ReportBoardService.java
@@ -25,7 +25,7 @@ public class ReportBoardService {
     private final UserRepository userRepository;
 
     @Transactional
-    public ReportBoardRes reportBoardRes(Long boardId, ReportBoardReq req) {
+    public ReportBoardRes reportBoard(Long boardId, ReportBoardReq req) {
         Board board = findBoardById(boardId);
 
         User user = userRepository.findById(req.getUserId());
@@ -48,7 +48,7 @@ public class ReportBoardService {
         // 허위 신고한 사용자의 점수 -50
         int count = 0; // 신고 횟수
         List<User> reporters = reportBoardRepository.selectUserByBoard(board);
-        for(User user : reporters) {
+        for (User user : reporters) {
             user.updateScore(-50);
             count++;
         }
@@ -62,7 +62,7 @@ public class ReportBoardService {
         return new DeleteReportBoardRes();
     }
 
-    private Board findBoardById(Long boardId){
+    private Board findBoardById(Long boardId) {
         Board board = boardRepository.findById(boardId);
         BoardValidator.validate(board);
         return board;

--- a/src/main/java/sparta/com/sappun/domain/ReportComment/controller/ReportCommentController.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportComment/controller/ReportCommentController.java
@@ -6,7 +6,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import sparta.com.sappun.domain.ReportBoard.dto.response.DeleteReportBoardRes;
 import sparta.com.sappun.domain.ReportComment.dto.request.ReportCommentReq;
+import sparta.com.sappun.domain.ReportComment.dto.response.DeleteReportCommentRes;
 import sparta.com.sappun.domain.ReportComment.dto.response.ReportCommentRes;
 import sparta.com.sappun.domain.ReportComment.service.ReportCommentService;
 import sparta.com.sappun.global.security.UserDetailsImpl;
@@ -24,5 +26,11 @@ public class ReportCommentController {
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         req.setUserId(userDetails.getUser().getId());
         return ResponseEntity.ok(reportCommentService.reportCommentRes(commentId, req));
+    }
+
+    @DeleteMapping("/{commentId}/report") // 필터에서 관리자만 접근하도록 막기
+    public ResponseEntity<DeleteReportCommentRes> deleteReportedComment(
+        @PathVariable Long commentId) {
+        return ResponseEntity.ok(reportCommentService.deleteReportComment(commentId));
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/ReportComment/controller/ReportCommentController.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportComment/controller/ReportCommentController.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import sparta.com.sappun.domain.ReportBoard.dto.response.DeleteReportBoardRes;
 import sparta.com.sappun.domain.ReportComment.dto.request.ReportCommentReq;
 import sparta.com.sappun.domain.ReportComment.dto.response.DeleteReportCommentRes;
 import sparta.com.sappun.domain.ReportComment.dto.response.ReportCommentRes;
@@ -30,7 +29,7 @@ public class ReportCommentController {
 
     @DeleteMapping("/{commentId}/report") // 필터에서 관리자만 접근하도록 막기
     public ResponseEntity<DeleteReportCommentRes> deleteReportedComment(
-        @PathVariable Long commentId) {
+            @PathVariable Long commentId) {
         return ResponseEntity.ok(reportCommentService.deleteReportComment(commentId));
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/ReportComment/dto/response/DeleteReportCommentRes.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportComment/dto/response/DeleteReportCommentRes.java
@@ -1,0 +1,8 @@
+package sparta.com.sappun.domain.ReportComment.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties
+public class DeleteReportCommentRes {
+
+}

--- a/src/main/java/sparta/com/sappun/domain/ReportComment/dto/response/DeleteReportCommentRes.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportComment/dto/response/DeleteReportCommentRes.java
@@ -3,6 +3,4 @@ package sparta.com.sappun.domain.ReportComment.dto.response;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties
-public class DeleteReportCommentRes {
-
-}
+public class DeleteReportCommentRes {}

--- a/src/main/java/sparta/com/sappun/domain/ReportComment/repository/ReportCommentRepository.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportComment/repository/ReportCommentRepository.java
@@ -1,10 +1,10 @@
 package sparta.com.sappun.domain.ReportComment.repository;
 
 import java.util.List;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.RepositoryDefinition;
 import sparta.com.sappun.domain.ReportComment.entity.ReportComment;
-import sparta.com.sappun.domain.board.entity.Board;
 import sparta.com.sappun.domain.comment.entity.Comment;
 import sparta.com.sappun.domain.user.entity.User;
 
@@ -16,6 +16,7 @@ public interface ReportCommentRepository {
     @Query(value = "select r.user FROM ReportComment r WHERE r.comment = :comment")
     List<User> selectUserByComment(Comment comment);
 
+    @Modifying // select 외의 쿼리를 사용하기 위해서 필요함
     @Query(value = "delete from ReportComment r where r.comment = :comment")
     void clearReportCommentByComment(Comment comment);
 }

--- a/src/main/java/sparta/com/sappun/domain/ReportComment/repository/ReportCommentRepository.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportComment/repository/ReportCommentRepository.java
@@ -1,10 +1,21 @@
 package sparta.com.sappun.domain.ReportComment.repository;
 
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.RepositoryDefinition;
 import sparta.com.sappun.domain.ReportComment.entity.ReportComment;
+import sparta.com.sappun.domain.board.entity.Board;
+import sparta.com.sappun.domain.comment.entity.Comment;
+import sparta.com.sappun.domain.user.entity.User;
 
 @RepositoryDefinition(domainClass = ReportComment.class, idClass = Long.class)
 public interface ReportCommentRepository {
 
     ReportComment save(ReportComment reportComment);
+
+    @Query(value = "select r.user FROM ReportComment r WHERE r.comment = :comment")
+    List<User> selectUserByComment(Comment comment);
+
+    @Query(value = "delete from ReportComment r where r.comment = :comment")
+    void clearReportCommentByComment(Comment comment);
 }

--- a/src/main/java/sparta/com/sappun/domain/ReportComment/service/ReportCommentService.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportComment/service/ReportCommentService.java
@@ -1,16 +1,21 @@
 package sparta.com.sappun.domain.ReportComment.service;
 
 import jakarta.transaction.Transactional;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import sparta.com.sappun.domain.ReportBoard.dto.response.DeleteReportBoardRes;
 import sparta.com.sappun.domain.ReportComment.dto.request.ReportCommentReq;
+import sparta.com.sappun.domain.ReportComment.dto.response.DeleteReportCommentRes;
 import sparta.com.sappun.domain.ReportComment.dto.response.ReportCommentRes;
 import sparta.com.sappun.domain.ReportComment.entity.ReportComment;
 import sparta.com.sappun.domain.ReportComment.repository.ReportCommentRepository;
+import sparta.com.sappun.domain.board.entity.Board;
 import sparta.com.sappun.domain.comment.entity.Comment;
 import sparta.com.sappun.domain.comment.repository.CommentRepository;
 import sparta.com.sappun.domain.user.entity.User;
 import sparta.com.sappun.domain.user.repository.UserRepository;
+import sparta.com.sappun.global.validator.BoardValidator;
 import sparta.com.sappun.global.validator.CommentValidator;
 import sparta.com.sappun.global.validator.UserValidator;
 
@@ -37,5 +42,32 @@ public class ReportCommentService {
         reportCommentRepository.save(reportComment);
 
         return ReportCommentServiceMapper.INSTANCE.toReportCommentRes(reportComment);
+    }
+
+    @Transactional
+    public DeleteReportCommentRes deleteReportComment(Long commentId) {
+        Comment comment = findCommentById(commentId);
+
+        // 허위 신고한 사용자의 점수 -50
+        int count = 0; // 신고 횟수
+        List<User> reporters = reportCommentRepository.selectUserByComment(comment);
+        for(User user : reporters) {
+            user.updateScore(-50);
+            count++;
+        }
+
+        // 신고 취소된 게시글의 작성자의 점수 +50 * 신고 횟수
+        comment.getUser().updateScore(50 * count);
+
+        // 신고 내역 삭제
+        reportCommentRepository.clearReportCommentByComment(comment);
+
+        return new DeleteReportCommentRes();
+    }
+
+    private Comment findCommentById(Long commentId){
+        Comment comment = commentRepository.findById(commentId);
+        CommentValidator.validate(comment);
+        return comment;
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/ReportComment/service/ReportCommentService.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportComment/service/ReportCommentService.java
@@ -4,18 +4,15 @@ import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import sparta.com.sappun.domain.ReportBoard.dto.response.DeleteReportBoardRes;
 import sparta.com.sappun.domain.ReportComment.dto.request.ReportCommentReq;
 import sparta.com.sappun.domain.ReportComment.dto.response.DeleteReportCommentRes;
 import sparta.com.sappun.domain.ReportComment.dto.response.ReportCommentRes;
 import sparta.com.sappun.domain.ReportComment.entity.ReportComment;
 import sparta.com.sappun.domain.ReportComment.repository.ReportCommentRepository;
-import sparta.com.sappun.domain.board.entity.Board;
 import sparta.com.sappun.domain.comment.entity.Comment;
 import sparta.com.sappun.domain.comment.repository.CommentRepository;
 import sparta.com.sappun.domain.user.entity.User;
 import sparta.com.sappun.domain.user.repository.UserRepository;
-import sparta.com.sappun.global.validator.BoardValidator;
 import sparta.com.sappun.global.validator.CommentValidator;
 import sparta.com.sappun.global.validator.UserValidator;
 
@@ -51,7 +48,7 @@ public class ReportCommentService {
         // 허위 신고한 사용자의 점수 -50
         int count = 0; // 신고 횟수
         List<User> reporters = reportCommentRepository.selectUserByComment(comment);
-        for(User user : reporters) {
+        for (User user : reporters) {
             user.updateScore(-50);
             count++;
         }
@@ -65,7 +62,7 @@ public class ReportCommentService {
         return new DeleteReportCommentRes();
     }
 
-    private Comment findCommentById(Long commentId){
+    private Comment findCommentById(Long commentId) {
         Comment comment = commentRepository.findById(commentId);
         CommentValidator.validate(comment);
         return comment;

--- a/src/main/java/sparta/com/sappun/global/response/ResultCode.java
+++ b/src/main/java/sparta/com/sappun/global/response/ResultCode.java
@@ -13,7 +13,7 @@ public enum ResultCode {
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "액세스 토큰이 유효하지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 유효하지 않습니다."),
     LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "재로그인 해주세요."),
-    ACCESS_DENY(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
     // 유저
     NOT_MATCHED_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),

--- a/src/main/java/sparta/com/sappun/global/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/sparta/com/sappun/global/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,36 @@
+package sparta.com.sappun.global.security;
+
+import static sparta.com.sappun.global.response.ResultCode.ACCESS_DENIED;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import sparta.com.sappun.global.response.CommonResponse;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException)
+            throws IOException {
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setCharacterEncoding("UTF-8");
+
+        CommonResponse<String> res = CommonResponse.error(ACCESS_DENIED.getMessage());
+        response.getWriter().write(objectMapper.writeValueAsString(res));
+    }
+}

--- a/src/main/java/sparta/com/sappun/global/security/WebSecurityConfig.java
+++ b/src/main/java/sparta/com/sappun/global/security/WebSecurityConfig.java
@@ -30,6 +30,7 @@ public class WebSecurityConfig {
     private final JwtUtil jwtUtil;
     private final RedisUtil redisUtil;
     private final UserDetailsServiceImpl userDetailsService;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -74,6 +75,10 @@ public class WebSecurityConfig {
                                 .anyRequest()
                                 .authenticated() // 그 외 모든 요청 인증처리
                 );
+
+        http.exceptionHandling(
+                authenticationManager ->
+                        authenticationManager.accessDeniedHandler(customAccessDeniedHandler));
 
         // 필터 관리
         http.addFilterBefore(jwtAuthorizationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/sparta/com/sappun/global/security/WebSecurityConfig.java
+++ b/src/main/java/sparta/com/sappun/global/security/WebSecurityConfig.java
@@ -1,5 +1,8 @@
 package sparta.com.sappun.global.security;
 
+import static org.springframework.http.HttpMethod.DELETE;
+import static sparta.com.sappun.domain.user.entity.Role.ADMIN;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -64,6 +67,10 @@ public class WebSecurityConfig {
                                 .permitAll() // resources 접근 허용 설정
                                 .requestMatchers("/api/users/signup", "/api/users/login")
                                 .permitAll() // 회원가입, 로그인 API만 접근 허용
+                                .requestMatchers(DELETE, "/api/boards/{boardId}/report")
+                                .hasAuthority(ADMIN.getAuthority()) // 게시글 신고 삭제는 관리자만 가능
+                                .requestMatchers(DELETE, "/api/comments/{commentId}/report")
+                                .hasAuthority(ADMIN.getAuthority()) // 게시글 신고 삭제는 관리자만 가능
                                 .anyRequest()
                                 .authenticated() // 그 외 모든 요청 인증처리
                 );

--- a/src/main/java/sparta/com/sappun/global/validator/BoardValidator.java
+++ b/src/main/java/sparta/com/sappun/global/validator/BoardValidator.java
@@ -1,6 +1,6 @@
 package sparta.com.sappun.global.validator;
 
-import static sparta.com.sappun.global.response.ResultCode.ACCESS_DENY;
+import static sparta.com.sappun.global.response.ResultCode.ACCESS_DENIED;
 import static sparta.com.sappun.global.response.ResultCode.NOT_FOUND_BOARD;
 
 import sparta.com.sappun.domain.board.entity.Board;
@@ -17,13 +17,13 @@ public class BoardValidator {
 
     public static void checkBoardUser(Long id, Long userId) {
         if (!id.equals(userId)) {
-            throw new GlobalException(ACCESS_DENY);
+            throw new GlobalException(ACCESS_DENIED);
         }
     }
 
     public static void checkBoardUser(User accessor, User author) {
         if (!accessor.getId().equals(author.getId()) && accessor.getRole() != Role.ADMIN) {
-            throw new GlobalException(ACCESS_DENY);
+            throw new GlobalException(ACCESS_DENIED);
         }
     }
 

--- a/src/main/java/sparta/com/sappun/global/validator/CommentValidator.java
+++ b/src/main/java/sparta/com/sappun/global/validator/CommentValidator.java
@@ -1,6 +1,6 @@
 package sparta.com.sappun.global.validator;
 
-import static sparta.com.sappun.global.response.ResultCode.ACCESS_DENY;
+import static sparta.com.sappun.global.response.ResultCode.ACCESS_DENIED;
 import static sparta.com.sappun.global.response.ResultCode.NOT_FOUND_COMMENT;
 
 import sparta.com.sappun.domain.comment.entity.Comment;
@@ -18,14 +18,14 @@ public class CommentValidator {
 
     public static void checkCommentUser(Long id, Long userId) { // 접근자와 작성자가 동일한지 확인
         if (!id.equals(userId)) {
-            throw new GlobalException(ACCESS_DENY);
+            throw new GlobalException(ACCESS_DENIED);
         }
     }
 
     public static void checkCommentUser(User accessor, User author) {
         if (!accessor.getId().equals(author.getId())
                 && accessor.getRole() != Role.ADMIN) { // 접근자와 작성자가 동일하거나 접근자가 관리자인지 확인
-            throw new GlobalException(ACCESS_DENY);
+            throw new GlobalException(ACCESS_DENIED);
         }
     }
 


### PR DESCRIPTION
## 개요
관리자의 게시글, 댓글 신고 취소 기능을 추가합니다.

## 작업사항
- 관리자의 게시글 신고 취소 기능 추가
- 관리자의 댓글 신고 취소 기능 추가
- 관리자만 신고 취소 가능하도록 필터 설정
- 권한 예외 필터 추가

## 관련 이슈
- 신고/좋아요를 토글 형식으로 바꾼 뒤 테스트 코드 작성하겠습니다
- close #65 
