### PR TITLE
좋아요. 신고 중복 불가능하도록 수정

### DIFF
--- a/src/main/java/sparta/com/sappun/domain/LikeBoard/contorller/LikeBoardLikeController.java
+++ b/src/main/java/sparta/com/sappun/domain/LikeBoard/contorller/LikeBoardLikeController.java
@@ -21,6 +21,6 @@ public class LikeBoardLikeController {
     public CommonResponse<LikeBoardSaveRes> likeBoard(
             @PathVariable Long boardId, @AuthenticationPrincipal UserDetailsImpl userId) {
         return CommonResponse.success(
-                likeBoardService.likeBoardSaveRes(boardId, userId.getUser().getId()));
+                likeBoardService.clickLikeBoard(boardId, userId.getUser().getId()));
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/LikeBoard/repository/LikeBoardRepository.java
+++ b/src/main/java/sparta/com/sappun/domain/LikeBoard/repository/LikeBoardRepository.java
@@ -2,8 +2,14 @@ package sparta.com.sappun.domain.LikeBoard.repository;
 
 import org.springframework.data.repository.RepositoryDefinition;
 import sparta.com.sappun.domain.LikeBoard.entity.LikeBoard;
+import sparta.com.sappun.domain.board.entity.Board;
+import sparta.com.sappun.domain.user.entity.User;
 
 @RepositoryDefinition(domainClass = LikeBoard.class, idClass = Long.class)
 public interface LikeBoardRepository {
     LikeBoard save(LikeBoard boardLike);
+
+    boolean existsLikeBoardByBoardAndUser(Board board, User user);
+
+    void deleteLikeBoardByBoardAndUser(Board board, User user);
 }

--- a/src/main/java/sparta/com/sappun/domain/LikeBoard/service/LikeBoardService.java
+++ b/src/main/java/sparta/com/sappun/domain/LikeBoard/service/LikeBoardService.java
@@ -22,15 +22,20 @@ public class LikeBoardService {
     private final UserRepository userRepository;
 
     @Transactional
-    public LikeBoardSaveRes likeBoardSaveRes(Long boardId, Long userId) {
+    public LikeBoardSaveRes clickLikeBoard(Long boardId, Long userId) {
         User user = userRepository.findById(userId);
         UserValidator.validate(user);
         Board board = boardRepository.findById(boardId);
         BoardValidator.validate(board);
 
-        board.getUser().updateScore(10); // 좋아요를 받은 게시글의 작성자 점수 +10
+        if (likeBoardRepository.existsLikeBoardByBoardAndUser(board, user)) { // 이미 좋아요를 누른 상태라면
+            board.getUser().updateScore(-10); // 좋아요를 받은 게시글의 작성자 점수 -10
+            likeBoardRepository.deleteLikeBoardByBoardAndUser(board, user); // 좋아요 삭제
+        } else { // 좋아요를 안 누른 상태라면
+            board.getUser().updateScore(10); // 좋아요를 받은 게시글의 작성자 점수 +10
+            likeBoardRepository.save(LikeBoard.builder().board(board).user(user).build()); // 좋아요 저장
+        }
 
-        likeBoardRepository.save(LikeBoard.builder().board(board).user(user).build());
         return new LikeBoardSaveRes();
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/LikeComment/contorller/LikeCommentLikeController.java
+++ b/src/main/java/sparta/com/sappun/domain/LikeComment/contorller/LikeCommentLikeController.java
@@ -18,6 +18,6 @@ public class LikeCommentLikeController {
     public CommonResponse<LikeCommentSaveRes> likeComment(
             @PathVariable Long commentId, @AuthenticationPrincipal UserDetailsImpl userId) {
         return CommonResponse.success(
-                likeCommentService.likeCommentSaveRes(commentId, userId.getUser().getId()));
+                likeCommentService.clickLikeComment(commentId, userId.getUser().getId()));
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/LikeComment/repository/LikeCommentRepository.java
+++ b/src/main/java/sparta/com/sappun/domain/LikeComment/repository/LikeCommentRepository.java
@@ -2,8 +2,14 @@ package sparta.com.sappun.domain.LikeComment.repository;
 
 import org.springframework.data.repository.RepositoryDefinition;
 import sparta.com.sappun.domain.LikeComment.entity.LikeComment;
+import sparta.com.sappun.domain.comment.entity.Comment;
+import sparta.com.sappun.domain.user.entity.User;
 
 @RepositoryDefinition(domainClass = LikeComment.class, idClass = Long.class)
 public interface LikeCommentRepository {
     LikeComment save(LikeComment commentLike);
+
+    boolean existsLikeCommentByCommentAndUser(Comment comment, User user);
+
+    void deleteLikeCommentByCommentAndUser(Comment comment, User user);
 }

--- a/src/main/java/sparta/com/sappun/domain/LikeComment/service/LikeCommentService.java
+++ b/src/main/java/sparta/com/sappun/domain/LikeComment/service/LikeCommentService.java
@@ -23,15 +23,21 @@ public class LikeCommentService {
     private final UserRepository userRepository;
 
     @Transactional
-    public LikeCommentSaveRes likeCommentSaveRes(Long commentId, Long userId) {
+    public LikeCommentSaveRes clickLikeComment(Long commentId, Long userId) {
         User user = userRepository.findById(userId);
         UserValidator.validate(user);
         Comment comment = commentRepository.findById(commentId);
         CommentValidator.validate(comment);
 
-        comment.getUser().updateScore(10); // 좋아요를 받은 댓글의 작성자 점수 +10
+        if (likeCommentRepository.existsLikeCommentByCommentAndUser(comment, user)) { // 이미 좋아요를 누른 상태라면
+            comment.getUser().updateScore(-10); // 좋아요를 받은 댓글의 작성자 점수 -10
+            likeCommentRepository.deleteLikeCommentByCommentAndUser(comment, user); // 좋아요 삭제
+        } else { // 좋아요를 안 누른 상태라면
+            comment.getUser().updateScore(10); // 좋아요를 받은 댓글의 작성자 점수 +10
+            likeCommentRepository.save(
+                    LikeComment.builder().comment(comment).user(user).build()); // 좋아요 저장
+        }
 
-        likeCommentRepository.save(LikeComment.builder().comment(comment).user(user).build());
         return new LikeCommentSaveRes();
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/ReportBoard/contorller/ReportBoardController.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportBoard/contorller/ReportBoardController.java
@@ -25,7 +25,7 @@ public class ReportBoardController {
             @RequestBody @Valid ReportBoardReq req,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         req.setUserId(userDetails.getUser().getId());
-        return ResponseEntity.ok(reportBoardService.reportBoard(boardId, req));
+        return ResponseEntity.ok(reportBoardService.clickReportBoard(boardId, req));
     }
 
     @DeleteMapping("/{boardId}/report") // 필터에서 관리자만 접근하도록 막기

--- a/src/main/java/sparta/com/sappun/domain/ReportBoard/repository/ReportBoardRepository.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportBoard/repository/ReportBoardRepository.java
@@ -12,6 +12,8 @@ import sparta.com.sappun.domain.user.entity.User;
 public interface ReportBoardRepository {
     ReportBoard save(ReportBoard reportBoard);
 
+    boolean existsReportBoardByBoardAndUser(Board board, User user);
+
     @Query(value = "select r.user FROM ReportBoard r WHERE r.board = :board")
     List<User> selectUserByBoard(Board board);
 

--- a/src/main/java/sparta/com/sappun/domain/ReportComment/controller/ReportCommentController.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportComment/controller/ReportCommentController.java
@@ -24,7 +24,7 @@ public class ReportCommentController {
             @RequestBody @Valid ReportCommentReq req,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         req.setUserId(userDetails.getUser().getId());
-        return ResponseEntity.ok(reportCommentService.reportComment(commentId, req));
+        return ResponseEntity.ok(reportCommentService.clickReportComment(commentId, req));
     }
 
     @DeleteMapping("/{commentId}/report") // 필터에서 관리자만 접근하도록 막기

--- a/src/main/java/sparta/com/sappun/domain/ReportComment/repository/ReportCommentRepository.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportComment/repository/ReportCommentRepository.java
@@ -13,6 +13,8 @@ public interface ReportCommentRepository {
 
     ReportComment save(ReportComment reportComment);
 
+    boolean existsReportBoardByCommentAndUser(Comment comment, User user);
+
     @Query(value = "select r.user FROM ReportComment r WHERE r.comment = :comment")
     List<User> selectUserByComment(Comment comment);
 

--- a/src/main/java/sparta/com/sappun/global/response/ResultCode.java
+++ b/src/main/java/sparta/com/sappun/global/response/ResultCode.java
@@ -32,6 +32,8 @@ public enum ResultCode {
     // 좋아요
 
     // 신고
+    DUPLICATED_REPORT_BOARD(HttpStatus.CONFLICT, "이미 신고한 게시글입니다."),
+    DUPLICATED_REPORT_COMMENT(HttpStatus.CONFLICT, "이미 신고한 댓글입니다."),
 
     // sample
     NOT_FOUND_SAMPLE(HttpStatus.NOT_FOUND, "존재하지 않는 샘플입니다.");

--- a/src/main/java/sparta/com/sappun/global/validator/ReportBoardValidator.java
+++ b/src/main/java/sparta/com/sappun/global/validator/ReportBoardValidator.java
@@ -1,0 +1,13 @@
+package sparta.com.sappun.global.validator;
+
+import static sparta.com.sappun.global.response.ResultCode.DUPLICATED_REPORT_BOARD;
+
+import sparta.com.sappun.global.exception.GlobalException;
+
+public class ReportBoardValidator {
+    public static void checkReport(boolean isDuplicated) {
+        if (isDuplicated) {
+            throw new GlobalException(DUPLICATED_REPORT_BOARD);
+        }
+    }
+}

--- a/src/main/java/sparta/com/sappun/global/validator/ReportCommentValidator.java
+++ b/src/main/java/sparta/com/sappun/global/validator/ReportCommentValidator.java
@@ -1,0 +1,13 @@
+package sparta.com.sappun.global.validator;
+
+import static sparta.com.sappun.global.response.ResultCode.DUPLICATED_REPORT_COMMENT;
+
+import sparta.com.sappun.global.exception.GlobalException;
+
+public class ReportCommentValidator {
+    public static void checkReport(boolean isDuplicated) {
+        if (isDuplicated) {
+            throw new GlobalException(DUPLICATED_REPORT_COMMENT);
+        }
+    }
+}

--- a/src/test/java/sparta/com/sappun/domain/LikeComment/contorller/LikeCommentLikeControllerTest.java
+++ b/src/test/java/sparta/com/sappun/domain/LikeComment/contorller/LikeCommentLikeControllerTest.java
@@ -1,6 +1,5 @@
 package sparta.com.sappun.domain.LikeComment.contorller;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -26,7 +25,7 @@ class LikeCommentLikeControllerTest extends BaseMvcTest implements LikeCommentTe
     void saveCommentTest() throws Exception {
         // given
         LikeCommentSaveRes res = new LikeCommentSaveRes();
-        when(likeCommentService.likeCommentSaveRes(any(), any())).thenReturn(res);
+        when(likeCommentService.clickLikeComment(any(), any())).thenReturn(res);
 
         // when-then
         mockMvc

--- a/src/test/java/sparta/com/sappun/domain/LikeComment/service/LikeCommentServiceTest.java
+++ b/src/test/java/sparta/com/sappun/domain/LikeComment/service/LikeCommentServiceTest.java
@@ -1,6 +1,5 @@
 package sparta.com.sappun.domain.LikeComment.service;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -34,8 +33,7 @@ class LikeCommentServiceTest implements CommentTest {
         when(userRepository.findById(any())).thenReturn(TEST_USER);
         when(commentRepository.findById(any())).thenReturn(TEST_COMMENT);
         // when
-        LikeCommentSaveRes result =
-                likecommentService.likeCommentSaveRes(TEST_COMMENT_ID, TEST_USER_ID);
+        LikeCommentSaveRes result = likecommentService.clickLikeComment(TEST_COMMENT_ID, TEST_USER_ID);
 
         // then
         verify(userRepository, times(1)).findById(TEST_USER_ID);

--- a/src/test/java/sparta/com/sappun/domain/ReportComment/contorller/ReportCommentControllerTest.java
+++ b/src/test/java/sparta/com/sappun/domain/ReportComment/contorller/ReportCommentControllerTest.java
@@ -1,6 +1,5 @@
 package sparta.com.sappun.domain.ReportComment.contorller;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -37,7 +36,7 @@ class ReportCommentControllerTest extends BaseMvcTest implements ReportCommentTe
                         .reason(TEST_COMMENT_REPORT_REASON)
                         .build();
 
-        when(reportCommentService.reportComment(any(), any())).thenReturn(res);
+        when(reportCommentService.clickReportComment(any(), any())).thenReturn(res);
 
         // when-then
         mockMvc

--- a/src/test/java/sparta/com/sappun/domain/ReportComment/service/ReportCommentServiceTest.java
+++ b/src/test/java/sparta/com/sappun/domain/ReportComment/service/ReportCommentServiceTest.java
@@ -37,11 +37,13 @@ class ReportCommentServiceTest implements ReportCommentTest {
         // given
         when(userRepository.findById(any())).thenReturn(TEST_USER);
         when(commentRepository.findById(any())).thenReturn(TEST_COMMENT);
+        when(reportCommentRepository.existsReportBoardByCommentAndUser(any(), any())).thenReturn(false);
         // when
-        reportCommentService.reportComment(TEST_COMMENT_ID, req);
+        reportCommentService.clickReportComment(TEST_COMMENT_ID, req);
         // then
         verify(userRepository, times(1)).findById(TEST_USER_ID);
         verify(commentRepository, times(1)).findById(TEST_COMMENT_ID);
+        verify(reportCommentRepository, times(1)).existsReportBoardByCommentAndUser(any(), any());
         verify(reportCommentRepository, times(1)).save(any());
     }
 }


### PR DESCRIPTION
## 개요
게시글 및 댓글의 좋아요와 신고가 중복 불가능하도록 수정합니다.

## 작업사항
- 게시글 및 댓글 좋아요를 토글 형식으로 수정
- 게시글 및 댓글 신고가 중복 불가능하도록 예외 처리 추가

## 관련 이슈
- 점수 관련 테스트 코드 이후에 작성하겠습니다.
- close #67 
