### PR TITLE
[#53, #59] Board 신고된 게시글 및 게시글 조회 수정

### DIFF
--- a/src/main/java/sparta/com/sappun/domain/ReportBoard/contorller/ReportBoardController.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportBoard/contorller/ReportBoardController.java
@@ -38,7 +38,6 @@ public class ReportBoardController {
     // 신고된 게시글 조회
     @GetMapping("/reports") // 필터에서 관리자만 접근하도록 막기
     public CommonResponse<ReportBoardListGetRes> getReportBoardList() {
-        ReportBoardListGetRes responseDto = reportBoardService.getReportBoardList();
-        return CommonResponse.success(responseDto);
+        return CommonResponse.success(reportBoardService.getReportBoardList());
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/ReportBoard/contorller/ReportBoardController.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportBoard/contorller/ReportBoardController.java
@@ -8,8 +8,10 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import sparta.com.sappun.domain.ReportBoard.dto.request.ReportBoardReq;
 import sparta.com.sappun.domain.ReportBoard.dto.response.DeleteReportBoardRes;
+import sparta.com.sappun.domain.ReportBoard.dto.response.ReportBoardListGetRes;
 import sparta.com.sappun.domain.ReportBoard.dto.response.ReportBoardRes;
 import sparta.com.sappun.domain.ReportBoard.service.ReportBoardService;
+import sparta.com.sappun.global.response.CommonResponse;
 import sparta.com.sappun.global.security.UserDetailsImpl;
 
 @RestController
@@ -31,5 +33,12 @@ public class ReportBoardController {
     @DeleteMapping("/{boardId}/report") // 필터에서 관리자만 접근하도록 막기
     public ResponseEntity<DeleteReportBoardRes> deleteReportedBoard(@PathVariable Long boardId) {
         return ResponseEntity.ok(reportBoardService.deleteReportBoard(boardId));
+    }
+
+    // 신고된 게시글 조회
+    @GetMapping("/reports") // 필터에서 관리자만 접근하도록 막기
+    public CommonResponse<ReportBoardListGetRes> getReportBoardList() {
+        ReportBoardListGetRes responseDto = reportBoardService.getReportBoardList();
+        return CommonResponse.success(responseDto);
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/ReportBoard/dto/response/ReportBoardGetRes.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportBoard/dto/response/ReportBoardGetRes.java
@@ -4,7 +4,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import sparta.com.sappun.domain.board.dto.response.BoardGetRes;
+import sparta.com.sappun.domain.board.dto.response.BoardToListGetRes;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -12,10 +12,10 @@ public class ReportBoardGetRes {
     private Long id;
     private String nickname;
     private String reason;
-    private BoardGetRes board;
+    private BoardToListGetRes board;
 
     @Builder
-    private ReportBoardGetRes(Long id, String reason, BoardGetRes board, String nickname) {
+    private ReportBoardGetRes(Long id, String reason, BoardToListGetRes board, String nickname) {
         this.id = id;
         this.reason = reason;
         this.board = board;

--- a/src/main/java/sparta/com/sappun/domain/ReportBoard/dto/response/ReportBoardGetRes.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportBoard/dto/response/ReportBoardGetRes.java
@@ -10,13 +10,15 @@ import sparta.com.sappun.domain.board.dto.response.BoardGetRes;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReportBoardGetRes {
     private Long id;
+    private String nickname;
     private String reason;
     private BoardGetRes board;
 
     @Builder
-    private ReportBoardGetRes(Long id, String reason, BoardGetRes board) {
+    private ReportBoardGetRes(Long id, String reason, BoardGetRes board, String nickname) {
         this.id = id;
         this.reason = reason;
         this.board = board;
+        this.nickname = nickname;
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/ReportBoard/dto/response/ReportBoardGetRes.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportBoard/dto/response/ReportBoardGetRes.java
@@ -1,0 +1,22 @@
+package sparta.com.sappun.domain.ReportBoard.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sparta.com.sappun.domain.board.dto.response.BoardGetRes;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReportBoardGetRes {
+    private Long id;
+    private String reason;
+    private BoardGetRes board;
+
+    @Builder
+    private ReportBoardGetRes(Long id, String reason, BoardGetRes board) {
+        this.id = id;
+        this.reason = reason;
+        this.board = board;
+    }
+}

--- a/src/main/java/sparta/com/sappun/domain/ReportBoard/dto/response/ReportBoardListGetRes.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportBoard/dto/response/ReportBoardListGetRes.java
@@ -1,0 +1,18 @@
+package sparta.com.sappun.domain.ReportBoard.dto.response;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReportBoardListGetRes {
+    private List<ReportBoardGetRes> reportBoards;
+
+    @Builder
+    private ReportBoardListGetRes(List<ReportBoardGetRes> reportBoards) {
+        this.reportBoards = reportBoards;
+    }
+}

--- a/src/main/java/sparta/com/sappun/domain/ReportBoard/repository/ReportBoardRepository.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportBoard/repository/ReportBoardRepository.java
@@ -20,4 +20,7 @@ public interface ReportBoardRepository {
     @Modifying // select 외의 쿼리를 사용하기 위해서 필요함
     @Query(value = "delete from ReportBoard r where r.board = :board")
     void clearReportBoardByBoard(Board board);
+
+    @Query("SELECT rb FROM ReportBoard rb JOIN FETCH rb.board")
+    List<ReportBoard> findAllFetchBoard();
 }

--- a/src/main/java/sparta/com/sappun/domain/ReportBoard/service/ReportBoardService.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportBoard/service/ReportBoardService.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import sparta.com.sappun.domain.ReportBoard.dto.request.ReportBoardReq;
 import sparta.com.sappun.domain.ReportBoard.dto.response.DeleteReportBoardRes;
+import sparta.com.sappun.domain.ReportBoard.dto.response.ReportBoardGetRes;
+import sparta.com.sappun.domain.ReportBoard.dto.response.ReportBoardListGetRes;
 import sparta.com.sappun.domain.ReportBoard.dto.response.ReportBoardRes;
 import sparta.com.sappun.domain.ReportBoard.entity.ReportBoard;
 import sparta.com.sappun.domain.ReportBoard.repository.ReportBoardRepository;
@@ -72,5 +74,13 @@ public class ReportBoardService {
         Board board = boardRepository.findById(boardId);
         BoardValidator.validate(board);
         return board;
+    }
+
+    @Transactional
+    public ReportBoardListGetRes getReportBoardList() {
+        List<ReportBoardGetRes> reportBoards =
+                ReportBoardServiceMapper.INSTANCE.toReportBoardListGetRes(
+                        reportBoardRepository.findAllFetchBoard());
+        return ReportBoardListGetRes.builder().reportBoards(reportBoards).build();
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/ReportBoard/service/ReportBoardServiceMapper.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportBoard/service/ReportBoardServiceMapper.java
@@ -1,8 +1,10 @@
 package sparta.com.sappun.domain.ReportBoard.service;
 
+import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
+import sparta.com.sappun.domain.ReportBoard.dto.response.ReportBoardGetRes;
 import sparta.com.sappun.domain.ReportBoard.dto.response.ReportBoardRes;
 import sparta.com.sappun.domain.ReportBoard.entity.ReportBoard;
 
@@ -13,4 +15,7 @@ public interface ReportBoardServiceMapper {
     @Mapping(source = "board.id", target = "reportedBoardId")
     @Mapping(source = "user.id", target = "reporterUserId")
     ReportBoardRes toReportBoardRes(ReportBoard reportBoard);
+
+    @Mapping(target = "boardGetRes.nickname", source = "reportBoard.board.nickname")
+    List<ReportBoardGetRes> toReportBoardListGetRes(List<ReportBoard> reportBoards);
 }

--- a/src/main/java/sparta/com/sappun/domain/ReportBoard/service/ReportBoardServiceMapper.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportBoard/service/ReportBoardServiceMapper.java
@@ -7,6 +7,10 @@ import org.mapstruct.factory.Mappers;
 import sparta.com.sappun.domain.ReportBoard.dto.response.ReportBoardGetRes;
 import sparta.com.sappun.domain.ReportBoard.dto.response.ReportBoardRes;
 import sparta.com.sappun.domain.ReportBoard.entity.ReportBoard;
+import sparta.com.sappun.domain.board.dto.response.BoardGetRes;
+import sparta.com.sappun.domain.board.entity.Board;
+import sparta.com.sappun.domain.comment.dto.response.CommentGetRes;
+import sparta.com.sappun.domain.comment.entity.Comment;
 
 @Mapper
 public interface ReportBoardServiceMapper {
@@ -16,6 +20,14 @@ public interface ReportBoardServiceMapper {
     @Mapping(source = "user.id", target = "reporterUserId")
     ReportBoardRes toReportBoardRes(ReportBoard reportBoard);
 
-    @Mapping(target = "boardGetRes.nickname", source = "reportBoard.board.nickname")
     List<ReportBoardGetRes> toReportBoardListGetRes(List<ReportBoard> reportBoards);
+
+    @Mapping(source = "user.nickname", target = "nickname")
+    CommentGetRes toCommentGetRes(Comment comment);
+
+    @Mapping(source = "user.nickname", target = "nickname")
+    BoardGetRes toBoardGetRes(Board board);
+
+    @Mapping(source = "user.nickname", target = "nickname")
+    ReportBoardGetRes toBoardGetRes(ReportBoard reportBoard);
 }

--- a/src/main/java/sparta/com/sappun/domain/ReportBoard/service/ReportBoardServiceMapper.java
+++ b/src/main/java/sparta/com/sappun/domain/ReportBoard/service/ReportBoardServiceMapper.java
@@ -7,7 +7,7 @@ import org.mapstruct.factory.Mappers;
 import sparta.com.sappun.domain.ReportBoard.dto.response.ReportBoardGetRes;
 import sparta.com.sappun.domain.ReportBoard.dto.response.ReportBoardRes;
 import sparta.com.sappun.domain.ReportBoard.entity.ReportBoard;
-import sparta.com.sappun.domain.board.dto.response.BoardGetRes;
+import sparta.com.sappun.domain.board.dto.response.BoardToListGetRes;
 import sparta.com.sappun.domain.board.entity.Board;
 import sparta.com.sappun.domain.comment.dto.response.CommentGetRes;
 import sparta.com.sappun.domain.comment.entity.Comment;
@@ -26,8 +26,8 @@ public interface ReportBoardServiceMapper {
     CommentGetRes toCommentGetRes(Comment comment);
 
     @Mapping(source = "user.nickname", target = "nickname")
-    BoardGetRes toBoardGetRes(Board board);
+    ReportBoardGetRes toBoardGetRes(ReportBoard reportBoard);
 
     @Mapping(source = "user.nickname", target = "nickname")
-    ReportBoardGetRes toBoardGetRes(ReportBoard reportBoard);
+    BoardToListGetRes toBoardToListGetRes(Board board);
 }

--- a/src/main/java/sparta/com/sappun/domain/board/dto/response/BoardBestListGetRes.java
+++ b/src/main/java/sparta/com/sappun/domain/board/dto/response/BoardBestListGetRes.java
@@ -9,10 +9,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BoardBestListGetRes {
-    private List<BoardGetRes> boards;
+    private List<BoardToListGetRes> boards;
 
     @Builder
-    private BoardBestListGetRes(List<BoardGetRes> boards) {
+    private BoardBestListGetRes(List<BoardToListGetRes> boards) {
         this.boards = boards;
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/board/dto/response/BoardGetRes.java
+++ b/src/main/java/sparta/com/sappun/domain/board/dto/response/BoardGetRes.java
@@ -11,6 +11,7 @@ import sparta.com.sappun.domain.comment.dto.response.CommentGetRes;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BoardGetRes {
+    private Long id;
     private String nickname;
     private String title;
     private String content;
@@ -24,6 +25,7 @@ public class BoardGetRes {
 
     @Builder
     private BoardGetRes(
+            Long id,
             String nickname,
             String title,
             String content,
@@ -33,6 +35,7 @@ public class BoardGetRes {
             List<String> stopover,
             RegionEnum region,
             List<CommentGetRes> comments) {
+        this.id = id;
         this.nickname = nickname;
         this.title = title;
         this.content = content;

--- a/src/main/java/sparta/com/sappun/domain/board/dto/response/BoardListGetRes.java
+++ b/src/main/java/sparta/com/sappun/domain/board/dto/response/BoardListGetRes.java
@@ -9,10 +9,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BoardListGetRes {
-    private List<BoardGetRes> boards;
+    private List<BoardToListGetRes> boards;
 
     @Builder
-    private BoardListGetRes(List<BoardGetRes> boards) {
+    private BoardListGetRes(List<BoardToListGetRes> boards) {
         this.boards = boards;
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/board/dto/response/BoardSaveRes.java
+++ b/src/main/java/sparta/com/sappun/domain/board/dto/response/BoardSaveRes.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import sparta.com.sappun.domain.board.entity.RegionEnum;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -17,6 +18,7 @@ public class BoardSaveRes {
     private String departure;
     private String destination;
     private List<String> stopover;
+    private RegionEnum region;
 
     @Builder
     private BoardSaveRes(
@@ -27,7 +29,8 @@ public class BoardSaveRes {
             String fileURL,
             String departure,
             String destination,
-            List<String> stopover) {
+            List<String> stopover,
+            RegionEnum region) {
         this.nickname = nickname;
         this.id = id;
         this.title = title;
@@ -36,5 +39,6 @@ public class BoardSaveRes {
         this.departure = departure;
         this.destination = destination;
         this.stopover = stopover;
+        this.region = region;
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/board/dto/response/BoardToListGetRes.java
+++ b/src/main/java/sparta/com/sappun/domain/board/dto/response/BoardToListGetRes.java
@@ -1,0 +1,41 @@
+package sparta.com.sappun.domain.board.dto.response;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sparta.com.sappun.domain.board.entity.RegionEnum;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BoardToListGetRes {
+    private Long id;
+    private String nickname;
+    private String title;
+    private String fileURL;
+    private String departure;
+    private String destination;
+    private List<String> stopover;
+    private RegionEnum region;
+
+    @Builder
+    private BoardToListGetRes(
+            Long id,
+            String nickname,
+            String title,
+            String fileURL,
+            String departure,
+            String destination,
+            List<String> stopover,
+            RegionEnum region) {
+        this.id = id;
+        this.nickname = nickname;
+        this.title = title;
+        this.fileURL = fileURL;
+        this.departure = departure;
+        this.destination = destination;
+        this.stopover = stopover;
+        this.region = region;
+    }
+}

--- a/src/main/java/sparta/com/sappun/domain/board/dto/response/BoardUpdateRes.java
+++ b/src/main/java/sparta/com/sappun/domain/board/dto/response/BoardUpdateRes.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import sparta.com.sappun.domain.board.entity.RegionEnum;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -17,6 +18,7 @@ public class BoardUpdateRes {
     private String departure;
     private String destination;
     private List<String> stopover;
+    private RegionEnum region;
 
     @Builder
     private BoardUpdateRes(
@@ -27,7 +29,8 @@ public class BoardUpdateRes {
             String fileURL,
             String departure,
             String destination,
-            List<String> stopover) {
+            List<String> stopover,
+            RegionEnum region) {
         this.nickname = nickname;
         this.id = id;
         this.title = title;
@@ -36,5 +39,6 @@ public class BoardUpdateRes {
         this.departure = departure;
         this.destination = destination;
         this.stopover = stopover;
+        this.region = region;
     }
 }

--- a/src/main/java/sparta/com/sappun/domain/board/service/BoardService.java
+++ b/src/main/java/sparta/com/sappun/domain/board/service/BoardService.java
@@ -31,14 +31,14 @@ public class BoardService {
 
     @Transactional(readOnly = true)
     public BoardListGetRes getBoardList(RegionEnum region) {
-        List<BoardGetRes> boardGetRes =
+        List<BoardToListGetRes> boardGetRes =
                 BoardServiceMapper.INSTANCE.toBoardListGetRes(boardRepository.findAllByRegion(region));
         return BoardListGetRes.builder().boards(boardGetRes).build();
     }
 
     @Transactional(readOnly = true)
     public BoardBestListGetRes getBoardBestList() {
-        List<BoardGetRes> boardGetRes =
+        List<BoardToListGetRes> boardGetRes =
                 BoardServiceMapper.INSTANCE.toBoardBestListGetRes(
                         boardRepository.findTop3ByOrderByLikeBoardDesc());
         return BoardBestListGetRes.builder().boards(boardGetRes).build();

--- a/src/main/java/sparta/com/sappun/domain/board/service/BoardServiceMapper.java
+++ b/src/main/java/sparta/com/sappun/domain/board/service/BoardServiceMapper.java
@@ -6,6 +6,7 @@ import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 import sparta.com.sappun.domain.board.dto.response.BoardGetRes;
 import sparta.com.sappun.domain.board.dto.response.BoardSaveRes;
+import sparta.com.sappun.domain.board.dto.response.BoardToListGetRes;
 import sparta.com.sappun.domain.board.dto.response.BoardUpdateRes;
 import sparta.com.sappun.domain.board.entity.Board;
 import sparta.com.sappun.domain.comment.dto.response.CommentGetRes;
@@ -18,15 +19,18 @@ public interface BoardServiceMapper {
     @Mapping(source = "user.nickname", target = "nickname")
     BoardGetRes toBoardGetRes(Board board);
 
-    List<BoardGetRes> toBoardListGetRes(List<Board> boardList);
+    @Mapping(source = "user.nickname", target = "nickname")
+    CommentGetRes toCommentGetRes(Comment comment);
 
-    List<BoardGetRes> toBoardBestListGetRes(List<Board> boardList);
+    List<BoardToListGetRes> toBoardListGetRes(List<Board> boardList);
+
+    List<BoardToListGetRes> toBoardBestListGetRes(List<Board> boardList);
+
+    @Mapping(source = "user.nickname", target = "nickname")
+    BoardToListGetRes toBoardToListGetRes(Board board);
 
     @Mapping(source = "user.nickname", target = "nickname")
     BoardSaveRes toBoardSaveRes(Board board);
-
-    @Mapping(source = "user.nickname", target = "nickname")
-    CommentGetRes toCommentGetRes(Comment comment);
 
     @Mapping(source = "user.nickname", target = "nickname")
     BoardUpdateRes toBoardUpdateRes(Board board);

--- a/src/main/java/sparta/com/sappun/global/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/sparta/com/sappun/global/jwt/JwtAuthorizationFilter.java
@@ -33,7 +33,10 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     private static final List<RequestMatcher> whiteList =
             List.of(
                     new AntPathRequestMatcher("/api/users/signup", HttpMethod.POST.name()),
-                    new AntPathRequestMatcher("/api/users/login", HttpMethod.POST.name()));
+                    new AntPathRequestMatcher("/api/users/login", HttpMethod.POST.name()),
+                    new AntPathRequestMatcher("/api/boards/best", HttpMethod.GET.name()),
+                    new AntPathRequestMatcher("/api/boards/{boardId}", HttpMethod.GET.name()),
+                    new AntPathRequestMatcher("/api/boards/region", HttpMethod.GET.name()));
 
     private final JwtUtil jwtUtil;
     private final RedisUtil redisUtil;

--- a/src/main/java/sparta/com/sappun/global/security/WebSecurityConfig.java
+++ b/src/main/java/sparta/com/sappun/global/security/WebSecurityConfig.java
@@ -75,6 +75,8 @@ public class WebSecurityConfig {
                                 .permitAll()
                                 .requestMatchers("/**.html")
                                 .permitAll()
+                                .requestMatchers("/api/boards/region", "/api/boards/best", "/api/boards/{boardId}")
+                                .permitAll() // 게시글 단건 조회, 게시글 목록 조회, 좋아요 Best 3 게시글 목록 조회 접근 허용
                                 .requestMatchers(DELETE, "/api/boards/{boardId}/report")
                                 .hasAuthority(ADMIN.getAuthority()) // 게시글 신고 삭제는 관리자만 가능
                                 .requestMatchers(DELETE, "/api/comments/{commentId}/report")
@@ -82,7 +84,8 @@ public class WebSecurityConfig {
                                 .requestMatchers(GET, "/api/boards/reports")
                                 .hasAuthority(ADMIN.getAuthority()) // 신고된 게시글 목록 조회는 관리자만 가능
                                 .anyRequest()
-                                .authenticated()); // 그 외 모든 요청 인증처리
+                                .authenticated() // 그 외 모든 요청 인증처리
+                );
 
         http.exceptionHandling(
                 authenticationManager ->

--- a/src/main/java/sparta/com/sappun/global/security/WebSecurityConfig.java
+++ b/src/main/java/sparta/com/sappun/global/security/WebSecurityConfig.java
@@ -1,6 +1,7 @@
 package sparta.com.sappun.global.security;
 
 import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.GET;
 import static sparta.com.sappun.domain.user.entity.Role.ADMIN;
 
 import lombok.RequiredArgsConstructor;
@@ -78,6 +79,8 @@ public class WebSecurityConfig {
                                 .hasAuthority(ADMIN.getAuthority()) // 게시글 신고 삭제는 관리자만 가능
                                 .requestMatchers(DELETE, "/api/comments/{commentId}/report")
                                 .hasAuthority(ADMIN.getAuthority()) // 게시글 신고 삭제는 관리자만 가능
+                                .requestMatchers(GET, "/api/boards/reports")
+                                .hasAuthority(ADMIN.getAuthority()) // 신고된 게시글 목록 조회는 관리자만 가능
                                 .anyRequest()
                                 .authenticated()); // 그 외 모든 요청 인증처리
 


### PR DESCRIPTION
## 개요
신고된 게시글 및 게시글 조회 수정

## 작업사항
- 신고된 게시글 목록 조회 구현
- 조회 권한 허용
- BoardGetRes에 id추가
- BoardSaveRes와 BoardUpdateRes에 region 추가
- BoardServiceMapper, ReportBoardServiceMapper 맵핑 수정
- 게시글 목록 조회용 단건 조회 Response BoardToListGetRes 추가(기존 BoardGetRes에서 Comment, Content 제거)
- 신고된 게시글 목록 조회 시 신고자 id, nickname 출력

## 관련 이슈
- close #53 
- close #59 
