### PR TITLE
회원 탈퇴 로직 수정

### DIFF
--- a/src/main/java/sparta/com/sappun/domain/board/repository/BoardRepository.java
+++ b/src/main/java/sparta/com/sappun/domain/board/repository/BoardRepository.java
@@ -4,9 +4,12 @@ import java.awt.*;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.RepositoryDefinition;
 import sparta.com.sappun.domain.board.entity.Board;
 import sparta.com.sappun.domain.board.entity.RegionEnum;
+import sparta.com.sappun.domain.user.entity.User;
 
 @RepositoryDefinition(domainClass = Board.class, idClass = long.class)
 public interface BoardRepository {
@@ -20,4 +23,8 @@ public interface BoardRepository {
     Board save(Board board);
 
     void delete(Board board);
+
+    @Modifying
+    @Query(value = "delete from Board b where b.user = :user")
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/sparta/com/sappun/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/sparta/com/sappun/domain/comment/repository/CommentRepository.java
@@ -1,7 +1,10 @@
 package sparta.com.sappun.domain.comment.repository;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.RepositoryDefinition;
 import sparta.com.sappun.domain.comment.entity.Comment;
+import sparta.com.sappun.domain.user.entity.User;
 
 @RepositoryDefinition(domainClass = Comment.class, idClass = Long.class)
 public interface CommentRepository {
@@ -10,4 +13,8 @@ public interface CommentRepository {
     Comment findById(Long commentId);
 
     void delete(Comment comment);
+
+    @Modifying
+    @Query(value = "delete from Comment c where c.user = :user")
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/sparta/com/sappun/domain/likeBoard/repository/LikeBoardRepository.java
+++ b/src/main/java/sparta/com/sappun/domain/likeBoard/repository/LikeBoardRepository.java
@@ -1,5 +1,8 @@
 package sparta.com.sappun.domain.likeBoard.repository;
 
+import java.util.List;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.RepositoryDefinition;
 import sparta.com.sappun.domain.board.entity.Board;
 import sparta.com.sappun.domain.likeBoard.entity.LikeBoard;
@@ -12,4 +15,11 @@ public interface LikeBoardRepository {
     boolean existsLikeBoardByBoardAndUser(Board board, User user);
 
     void deleteLikeBoardByBoardAndUser(Board board, User user);
+
+    @Query(value = "select r FROM LikeBoard r WHERE r.user = :user")
+    List<LikeBoard> selectLikeBoardByUser(User user);
+
+    @Modifying
+    @Query(value = "delete from LikeBoard lb where lb in :likeBoards")
+    void deleteAll(List<LikeBoard> likeBoards);
 }

--- a/src/main/java/sparta/com/sappun/domain/likeComment/repository/LikeCommentRepository.java
+++ b/src/main/java/sparta/com/sappun/domain/likeComment/repository/LikeCommentRepository.java
@@ -1,5 +1,8 @@
 package sparta.com.sappun.domain.likeComment.repository;
 
+import java.util.List;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.RepositoryDefinition;
 import sparta.com.sappun.domain.comment.entity.Comment;
 import sparta.com.sappun.domain.likeComment.entity.LikeComment;
@@ -12,4 +15,11 @@ public interface LikeCommentRepository {
     boolean existsLikeCommentByCommentAndUser(Comment comment, User user);
 
     void deleteLikeCommentByCommentAndUser(Comment comment, User user);
+
+    @Query(value = "select r FROM LikeComment r WHERE r.user = :user")
+    List<LikeComment> selectLikeCommentByUser(User user);
+
+    @Modifying
+    @Query(value = "delete from LikeComment lc where lc in :likeComments")
+    void deleteAll(List<LikeComment> likeComments);
 }

--- a/src/main/java/sparta/com/sappun/domain/reportBoard/repository/ReportBoardRepository.java
+++ b/src/main/java/sparta/com/sappun/domain/reportBoard/repository/ReportBoardRepository.java
@@ -17,6 +17,13 @@ public interface ReportBoardRepository {
     @Query(value = "select r.user FROM ReportBoard r WHERE r.board = :board")
     List<User> selectUserByBoard(Board board);
 
+    @Query(value = "select r FROM ReportBoard r WHERE r.user = :user")
+    List<ReportBoard> selectReportBoardByUser(User user);
+
+    @Modifying
+    @Query(value = "delete from ReportBoard rb where rb in :reportBoards")
+    void deleteAll(List<ReportBoard> reportBoards);
+
     @Modifying // select 외의 쿼리를 사용하기 위해서 필요함
     @Query(value = "delete from ReportBoard r where r.board = :board")
     void clearReportBoardByBoard(Board board);

--- a/src/main/java/sparta/com/sappun/domain/reportComment/repository/ReportCommentRepository.java
+++ b/src/main/java/sparta/com/sappun/domain/reportComment/repository/ReportCommentRepository.java
@@ -18,6 +18,13 @@ public interface ReportCommentRepository {
     @Query(value = "select r.user FROM ReportComment r WHERE r.comment = :comment")
     List<User> selectUserByComment(Comment comment);
 
+    @Query(value = "select r FROM ReportComment r WHERE r.user = :user")
+    List<ReportComment> selectReportCommentByUser(User user);
+
+    @Modifying
+    @Query(value = "delete from ReportComment rc where rc in :reportComments")
+    void deleteAll(List<ReportComment> reportComments);
+
     @Modifying // select 외의 쿼리를 사용하기 위해서 필요함
     @Query(value = "delete from ReportComment r where r.comment = :comment")
     void clearReportCommentByComment(Comment comment);

--- a/src/test/java/sparta/com/sappun/domain/board/controller/BoardControllerTest.java
+++ b/src/test/java/sparta/com/sappun/domain/board/controller/BoardControllerTest.java
@@ -58,7 +58,7 @@ class BoardControllerTest extends BaseMvcTest implements BoardTest {
                         .stopover(TEST_STOPOVER)
                         .destination(TEST_DESTINATION)
                         .region(TEST_REGION1)
-                        .likeCount(TEST_LIKECOUNT)
+                        .likeCount(TEST_LIKE_COUNT)
                         .build();
 
         // when

--- a/src/test/java/sparta/com/sappun/domain/board/repository/BoardRepositoryTest.java
+++ b/src/test/java/sparta/com/sappun/domain/board/repository/BoardRepositoryTest.java
@@ -3,28 +3,39 @@ package sparta.com.sappun.domain.board.repository;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
 import java.util.List;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 import sparta.com.sappun.domain.board.entity.Board;
+import sparta.com.sappun.domain.user.entity.User;
+import sparta.com.sappun.domain.user.repository.UserRepository;
 import sparta.com.sappun.test.BoardTest;
 
-@Disabled
 @DataJpaTest
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class BoardRepositoryTest implements BoardTest {
+
     @Autowired private BoardRepository boardRepository;
+    @Autowired private UserRepository userRepository;
+
+    @PersistenceContext EntityManager em;
 
     @Test
     @DisplayName("save 테스트")
     void saveTest() {
         // given
+        userRepository.save(TEST_USER);
 
         // when
         Board saveBoard = boardRepository.save(TEST_BOARD);
@@ -38,20 +49,21 @@ class BoardRepositoryTest implements BoardTest {
         assertEquals(TEST_DESTINATION, saveBoard.getDestination());
         assertEquals(TEST_STOPOVER, saveBoard.getStopover());
         assertEquals(TEST_REGION1, saveBoard.getRegion());
-        assertEquals(TEST_LIKECOUNT, saveBoard.getLikeCount());
-        assertEquals(TEST_REPORTCOUNT, saveBoard.getReportCount());
+        assertEquals(TEST_LIKE_COUNT, saveBoard.getLikeCount());
+        assertEquals(TEST_REPORT_COUNT, saveBoard.getReportCount());
     }
 
     @Test
     @DisplayName("findById 테스트")
     void findByIdTest() {
         // given
+        userRepository.save(TEST_USER);
         Board board = boardRepository.save(TEST_BOARD);
+
         // when
         Board saveBoard = boardRepository.findById(board.getId());
 
         // then
-        assertEquals(TEST_BOARD_ID, saveBoard.getId());
         assertEquals(TEST_BOARD_TITLE, saveBoard.getTitle());
         assertEquals(TEST_BOARD_CONTENT, saveBoard.getContent());
         assertEquals(TEST_BOARD_URL, saveBoard.getFileURL());
@@ -59,8 +71,8 @@ class BoardRepositoryTest implements BoardTest {
         assertEquals(TEST_DESTINATION, saveBoard.getDestination());
         assertEquals(TEST_STOPOVER, saveBoard.getStopover());
         assertEquals(TEST_REGION1, saveBoard.getRegion());
-        assertEquals(TEST_LIKECOUNT, saveBoard.getLikeCount());
-        assertEquals(TEST_REPORTCOUNT, saveBoard.getReportCount());
+        assertEquals(TEST_LIKE_COUNT, saveBoard.getLikeCount());
+        assertEquals(TEST_REPORT_COUNT, saveBoard.getReportCount());
     }
 
     @Test
@@ -79,33 +91,75 @@ class BoardRepositoryTest implements BoardTest {
     @Test
     @DisplayName("findAllByRegion 테스트")
     void findAllByRegionTest() {
-        //        // given
-        //        Board board = boardRepository.save(TEST_BOARD);
-        //        Pageable pageable = (Pageable) PageRequest.ofSize (1);
-        //
-        //        // when
-        //        Page<Board> boardPage = boardRepository.findAllByRegion(board.getRegion(), pageable);
-        //
-        //        // then
-        //        assertEquals(TEST_BOARD_ID, boardPage.getId());
-        //        assertEquals(TEST_BOARD_TITLE, boardPage.getTitle());
-        //        assertEquals(TEST_BOARD_CONTENT, boardPage.getContent());
-        //        assertEquals(TEST_BOARD_URL, boardPage.getFileURL());
-        //        assertEquals(TEST_DEPARTURE, boardPage.getDeparture());
-        //        assertEquals(TEST_DESTINATION, boardPage.getDestination());
-        //        assertEquals(TEST_STOPOVER, boardPage.getStopover());
-        //        assertEquals(TEST_REGION1, boardPage.getRegion());
-        //        assertEquals(TEST_LIKECOUNT, boardPage.getLikeCount());
-        //        assertEquals(TEST_REPORTCOUNT, boardPage.getReportCount());
+        // given
+        Board board = boardRepository.save(TEST_BOARD);
+        Pageable pageable = PageRequest.ofSize(1);
+
+        // when
+        Page<Board> boardPage = boardRepository.findAllByRegion(board.getRegion(), pageable);
+
+        // then
+        assertEquals(TEST_BOARD_TITLE, boardPage.getContent().get(0).getTitle());
+        assertEquals(TEST_BOARD_CONTENT, boardPage.getContent().get(0).getContent());
+        assertEquals(TEST_BOARD_URL, boardPage.getContent().get(0).getFileURL());
+        assertEquals(TEST_DEPARTURE, boardPage.getContent().get(0).getDeparture());
+        assertEquals(TEST_DESTINATION, boardPage.getContent().get(0).getDestination());
+        assertEquals(TEST_STOPOVER, boardPage.getContent().get(0).getStopover());
+        assertEquals(TEST_REGION1, boardPage.getContent().get(0).getRegion());
+        assertEquals(TEST_LIKE_COUNT, boardPage.getContent().get(0).getLikeCount());
+        assertEquals(TEST_REPORT_COUNT, boardPage.getContent().get(0).getReportCount());
     }
 
     @Test
     @DisplayName("findTop3ByOrderByLikeCountDesc 테스트")
     void findTop3ByOrderByLikeCountDesc() {
         // given
-        Board board1 = boardRepository.save(TEST_BOARD);
-        Board board2 = boardRepository.save(TEST_BOARD1);
-        Board board3 = boardRepository.save(TEST_BOARD2);
+        User user = userRepository.save(TEST_USER);
+        Board board0 =
+                Board.builder()
+                        .user(user)
+                        .title(TEST_BOARD_TITLE)
+                        .content(TEST_BOARD_CONTENT)
+                        .fileURL(TEST_BOARD_URL)
+                        .departure(TEST_DEPARTURE)
+                        .destination(TEST_DESTINATION)
+                        .stopover(TEST_STOPOVER)
+                        .region(TEST_REGION1)
+                        .likeCount(0)
+                        .reportCount(TEST_REPORT_COUNT)
+                        .build();
+
+        Board board1 =
+                Board.builder()
+                        .user(user)
+                        .title(TEST_BOARD_TITLE)
+                        .content(TEST_BOARD_CONTENT)
+                        .fileURL(TEST_BOARD_URL)
+                        .departure(TEST_DEPARTURE)
+                        .destination(TEST_DESTINATION)
+                        .stopover(TEST_STOPOVER)
+                        .region(TEST_REGION1)
+                        .likeCount(1)
+                        .reportCount(TEST_REPORT_COUNT)
+                        .build();
+
+        Board board2 =
+                Board.builder()
+                        .user(user)
+                        .title(TEST_BOARD_TITLE)
+                        .content(TEST_BOARD_CONTENT)
+                        .fileURL(TEST_BOARD_URL)
+                        .departure(TEST_DEPARTURE)
+                        .destination(TEST_DESTINATION)
+                        .stopover(TEST_STOPOVER)
+                        .region(TEST_REGION1)
+                        .likeCount(2)
+                        .reportCount(TEST_REPORT_COUNT)
+                        .build();
+
+        boardRepository.save(board0);
+        boardRepository.save(board1);
+        boardRepository.save(board2);
 
         // when
         List<Board> top3Boards = boardRepository.findTop3ByOrderByLikeCountDesc();
@@ -115,5 +169,36 @@ class BoardRepositoryTest implements BoardTest {
         assertEquals(TEST_BOARD2.getLikeCount(), top3Boards.get(0).getLikeCount());
         assertEquals(TEST_BOARD1.getLikeCount(), top3Boards.get(1).getLikeCount());
         assertEquals(TEST_BOARD.getLikeCount(), top3Boards.get(2).getLikeCount());
+    }
+
+    @Test
+    @DisplayName("deleteAllByUser 테스트")
+    @Transactional
+    void deleteAllByUserTest() {
+        // given
+        User user = userRepository.save(TEST_USER);
+        Board board =
+                Board.builder()
+                        .user(user)
+                        .title(TEST_BOARD_TITLE)
+                        .content(TEST_BOARD_CONTENT)
+                        .fileURL(TEST_BOARD_URL)
+                        .departure(TEST_DEPARTURE)
+                        .destination(TEST_DESTINATION)
+                        .stopover(TEST_STOPOVER)
+                        .region(TEST_REGION1)
+                        .likeCount(0)
+                        .reportCount(TEST_REPORT_COUNT)
+                        .build();
+        boardRepository.save(board);
+
+        // when
+        boardRepository.deleteAllByUser(user);
+        em.flush(); // 변경사항을 데이터베이스에 즉시 반영
+        em.clear(); // 영속성 컨텍스트 초기화
+        Board findBoard = boardRepository.findById(board.getId());
+
+        // then
+        assertNull(findBoard);
     }
 }

--- a/src/test/java/sparta/com/sappun/domain/board/service/BoardServiceTest.java
+++ b/src/test/java/sparta/com/sappun/domain/board/service/BoardServiceTest.java
@@ -69,7 +69,7 @@ class BoardServiceTest implements BoardTest {
         assertEquals(TEST_DESTINATION, res.getDestination());
         assertEquals(TEST_STOPOVER, res.getStopover());
         assertEquals(TEST_REGION1, res.getRegion());
-        assertEquals(TEST_LIKECOUNT, res.getLikeCount());
+        assertEquals(TEST_LIKE_COUNT, res.getLikeCount());
     }
 
     @Test
@@ -84,8 +84,8 @@ class BoardServiceTest implements BoardTest {
         //                        .destination(TEST_DESTINATION)
         //                        .stopover(TEST_STOPOVER)
         //                        .region(TEST_REGION1)
-        //                        .likeCount(TEST_LIKECOUNT)
-        //                        .reportCount(TEST_REPORTCOUNT)
+        //                        .likeCount(TEST_LIKE_COUNT)
+        //                        .reportCount(TEST_REPORT_COUNT)
         //                        .build();
         //        req.setUserId(TEST_USER_ID);
         //
@@ -105,7 +105,7 @@ class BoardServiceTest implements BoardTest {
         //        assertEquals(TEST_DESTINATION, argumentCaptor.getValue().getDestination());
         //        assertEquals(TEST_STOPOVER, argumentCaptor.getValue().getStopover());
         //        assertEquals(TEST_REGION1, argumentCaptor.getValue().getRegion());
-        //        assertEquals(TEST_LIKECOUNT, argumentCaptor.getValue().getReportCount());
-        //        assertEquals(TEST_REPORTCOUNT, argumentCaptor.getValue().getLikeCount());
+        //        assertEquals(TEST_LIKE_COUNT, argumentCaptor.getValue().getReportCount());
+        //        assertEquals(TEST_REPORT_COUNT, argumentCaptor.getValue().getLikeCount());
     }
 }

--- a/src/test/java/sparta/com/sappun/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/sparta/com/sappun/domain/comment/repository/CommentRepositoryTest.java
@@ -2,14 +2,19 @@ package sparta.com.sappun.domain.comment.repository;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
+import sparta.com.sappun.domain.board.entity.Board;
 import sparta.com.sappun.domain.board.repository.BoardRepository;
 import sparta.com.sappun.domain.comment.entity.Comment;
+import sparta.com.sappun.domain.user.entity.User;
 import sparta.com.sappun.domain.user.repository.UserRepository;
 import sparta.com.sappun.test.CommentTest;
 
@@ -21,6 +26,8 @@ class CommentRepositoryTest implements CommentTest {
     @Autowired private CommentRepository commentRepository;
     @Autowired private UserRepository userRepository;
     @Autowired private BoardRepository boardRepository;
+
+    @PersistenceContext EntityManager em;
 
     @Test
     @DisplayName("save 테스트")
@@ -64,6 +71,34 @@ class CommentRepositoryTest implements CommentTest {
         // when
         // 데이터베이스에서 삭제
         commentRepository.delete(comment);
+        Comment findComment = commentRepository.findById(comment.getId());
+
+        // then
+        assertNull(findComment);
+    }
+
+    @Test
+    @DisplayName("deleteAllByUser 테스트")
+    @Transactional
+    void deleteAllByUserTest() {
+        // given
+        User user = userRepository.save(TEST_USER);
+        Board board = boardRepository.save(TEST_BOARD);
+        Comment comment =
+                Comment.builder()
+                        .content(TEST_COMMENT_CONTENT)
+                        .fileURL(TEST_COMMENT_FILEURL)
+                        .user(user)
+                        .board(board)
+                        .likeCount(TEST_LIKE_COUNT)
+                        .reportCount(TEST_REPORT_COUNT)
+                        .build();
+        commentRepository.save(comment);
+
+        // when
+        commentRepository.deleteAllByUser(user);
+        em.flush(); // 변경사항을 데이터베이스에 즉시 반영
+        em.clear(); // 영속성 컨텍스트 초기화
         Comment findComment = commentRepository.findById(comment.getId());
 
         // then

--- a/src/test/java/sparta/com/sappun/domain/likeBoard/repository/LikeBoardRepositoryTest.java
+++ b/src/test/java/sparta/com/sappun/domain/likeBoard/repository/LikeBoardRepositoryTest.java
@@ -2,14 +2,17 @@ package sparta.com.sappun.domain.likeBoard.repository;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
+import sparta.com.sappun.domain.board.entity.Board;
 import sparta.com.sappun.domain.board.repository.BoardRepository;
 import sparta.com.sappun.domain.likeBoard.entity.LikeBoard;
+import sparta.com.sappun.domain.user.entity.User;
 import sparta.com.sappun.domain.user.repository.UserRepository;
 import sparta.com.sappun.test.LikeBoardTest;
 
@@ -26,7 +29,6 @@ class LikeBoardRepositoryTest implements LikeBoardTest {
     @Test
     @DisplayName("게시글 좋아요 테스트")
     public void testSave() {
-
         // given
         userRepository.save(TEST_USER);
         boardRepository.save(TEST_BOARD);
@@ -34,8 +36,70 @@ class LikeBoardRepositoryTest implements LikeBoardTest {
         // when
         LikeBoard likeBoard = likeBoardRepository.save(TEST_LIKE_BOARD);
 
-        // thens
+        // then
         assertEquals(TEST_USER, likeBoard.getUser());
         assertEquals(TEST_BOARD, likeBoard.getBoard());
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요 찾기 테스트")
+    public void existsLikeBoardByBoardAndUserTest() {
+        // given
+        User user = userRepository.save(TEST_USER);
+        Board board = boardRepository.save(TEST_BOARD);
+        likeBoardRepository.save(TEST_LIKE_BOARD);
+
+        // when
+        boolean isExist = likeBoardRepository.existsLikeBoardByBoardAndUser(board, user);
+
+        // then
+        assertTrue(isExist);
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요 삭제 테스트")
+    public void deleteLikeBoardByBoardAndUserTest() {
+        // given
+        User user = userRepository.save(TEST_USER);
+        Board board = boardRepository.save(TEST_BOARD);
+        likeBoardRepository.save(TEST_LIKE_BOARD);
+
+        // when
+        likeBoardRepository.deleteLikeBoardByBoardAndUser(board, user);
+        boolean isExist = likeBoardRepository.existsLikeBoardByBoardAndUser(board, user);
+
+        // then
+        assertFalse(isExist);
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요 사용자로 찾기 테스트")
+    public void selectLikeBoardByUserTest() {
+        // given
+        User user = userRepository.save(TEST_USER);
+        Board board = boardRepository.save(TEST_BOARD);
+        likeBoardRepository.save(TEST_LIKE_BOARD);
+
+        // when
+        List<LikeBoard> likeBoardList = likeBoardRepository.selectLikeBoardByUser(user);
+
+        // then
+        assertEquals(board, likeBoardList.get(0).getBoard());
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요 목록 삭제 테스트")
+    public void deleteAllTest() {
+        // given
+        User user = userRepository.save(TEST_USER);
+        Board board = boardRepository.save(TEST_BOARD);
+        LikeBoard likeBoard = likeBoardRepository.save(TEST_LIKE_BOARD);
+
+        // when
+        likeBoardRepository.deleteAll(List.of(likeBoard));
+        boolean isExist = likeBoardRepository.existsLikeBoardByBoardAndUser(board, user);
+
+        // then
+        assertFalse(isExist);
     }
 }

--- a/src/test/java/sparta/com/sappun/domain/likeComment/repository/LikeCommentRepositoryTest.java
+++ b/src/test/java/sparta/com/sappun/domain/likeComment/repository/LikeCommentRepositoryTest.java
@@ -2,14 +2,18 @@ package sparta.com.sappun.domain.likeComment.repository;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 import sparta.com.sappun.domain.board.repository.BoardRepository;
+import sparta.com.sappun.domain.comment.entity.Comment;
 import sparta.com.sappun.domain.comment.repository.CommentRepository;
 import sparta.com.sappun.domain.likeComment.entity.LikeComment;
+import sparta.com.sappun.domain.user.entity.User;
 import sparta.com.sappun.domain.user.repository.UserRepository;
 import sparta.com.sappun.test.LikeCommentTest;
 
@@ -27,8 +31,8 @@ class LikeCommentRepositoryTest implements LikeCommentTest {
     @Autowired private BoardRepository boardRepository;
 
     @Test
+    @DisplayName("댓글 좋아요 저장 테스트")
     public void testSave() {
-
         // given
         userRepository.save(TEST_USER);
         boardRepository.save(TEST_BOARD);
@@ -37,8 +41,74 @@ class LikeCommentRepositoryTest implements LikeCommentTest {
         // when
         LikeComment likeComment = likeCommentRepository.save(TEST_LIKE_COMMENT);
 
-        // thens
+        // then
         assertEquals(TEST_USER, likeComment.getUser());
         assertEquals(TEST_COMMENT, likeComment.getComment());
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 찾기 테스트")
+    public void existsLikeCommentByCommentAndUserTest() {
+        // given
+        User user = userRepository.save(TEST_USER);
+        boardRepository.save(TEST_BOARD);
+        Comment comment = commentRepository.save(TEST_COMMENT);
+        likeCommentRepository.save(TEST_LIKE_COMMENT);
+
+        // when
+        boolean isExist = likeCommentRepository.existsLikeCommentByCommentAndUser(comment, user);
+
+        // then
+        assertTrue(isExist);
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 삭제 테스트")
+    public void deleteLikeCommentByCommentAndUserTest() {
+        // given
+        User user = userRepository.save(TEST_USER);
+        boardRepository.save(TEST_BOARD);
+        Comment comment = commentRepository.save(TEST_COMMENT);
+        likeCommentRepository.save(TEST_LIKE_COMMENT);
+
+        // when
+        likeCommentRepository.deleteLikeCommentByCommentAndUser(comment, user);
+        boolean isExist = likeCommentRepository.existsLikeCommentByCommentAndUser(comment, user);
+
+        // then
+        assertFalse(isExist);
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 사용자로 찾기 테스트")
+    public void selectLikeCommentByUserTest() {
+        // given
+        User user = userRepository.save(TEST_USER);
+        boardRepository.save(TEST_BOARD);
+        Comment comment = commentRepository.save(TEST_COMMENT);
+        likeCommentRepository.save(TEST_LIKE_COMMENT);
+
+        // when
+        List<LikeComment> likeCommentList = likeCommentRepository.selectLikeCommentByUser(user);
+
+        // then
+        assertEquals(comment, likeCommentList.get(0).getComment());
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 목록 삭제 테스트")
+    public void deleteAllTest() {
+        // given
+        User user = userRepository.save(TEST_USER);
+        boardRepository.save(TEST_BOARD);
+        Comment comment = commentRepository.save(TEST_COMMENT);
+        LikeComment likeComment = likeCommentRepository.save(TEST_LIKE_COMMENT);
+
+        // when
+        likeCommentRepository.deleteAll(List.of(likeComment));
+        boolean isExist = likeCommentRepository.existsLikeCommentByCommentAndUser(comment, user);
+
+        // then
+        assertFalse(isExist);
     }
 }

--- a/src/test/java/sparta/com/sappun/domain/reportBoard/repository/ReportBoardRepositoryTest.java
+++ b/src/test/java/sparta/com/sappun/domain/reportBoard/repository/ReportBoardRepositoryTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
+import sparta.com.sappun.domain.board.entity.Board;
 import sparta.com.sappun.domain.board.repository.BoardRepository;
 import sparta.com.sappun.domain.reportBoard.entity.ReportBoard;
 import sparta.com.sappun.domain.user.entity.User;
@@ -83,5 +84,51 @@ class ReportBoardRepositoryTest implements ReportBoardTest {
 
         // then
         assertEquals(0, reportBoardRepository.selectUserByBoard(TEST_BOARD).size());
+    }
+
+    @Test
+    @DisplayName("게시글 신고 selectReportBoardByUser 테스트")
+    void selectReportBoardByUserTest() {
+        // given
+        User user = userRepository.save(TEST_USER);
+        Board board = boardRepository.save(TEST_BOARD);
+        reportBoardRepository.save(REPORT_BOARD);
+
+        // when
+        List<ReportBoard> reportBoardList = reportBoardRepository.selectReportBoardByUser(user);
+
+        // then
+        assertEquals(reportBoardList.get(0).getBoard(), board);
+    }
+
+    @Test
+    @DisplayName("게시글 신고 deleteAll 테스트")
+    public void deleteAllTest() {
+        // given
+        User user = userRepository.save(TEST_USER);
+        Board board = boardRepository.save(TEST_BOARD);
+        ReportBoard reportBoard = reportBoardRepository.save(REPORT_BOARD);
+
+        // when
+        reportBoardRepository.deleteAll(List.of(reportBoard));
+        boolean isExist = reportBoardRepository.existsReportBoardByBoardAndUser(board, user);
+
+        // then
+        assertFalse(isExist);
+    }
+
+    @Test
+    @DisplayName("게시글 신고 findAllFetchBoard 테스트")
+    void findAllFetchBoardTest() {
+        // given
+        User user = userRepository.save(TEST_USER);
+        Board board = boardRepository.save(TEST_BOARD);
+        ReportBoard reportBoard = reportBoardRepository.save(REPORT_BOARD);
+
+        // when
+        List<ReportBoard> reportBoardList = reportBoardRepository.findAllFetchBoard();
+
+        // then
+        assertEquals(reportBoardList.get(0), reportBoard);
     }
 }

--- a/src/test/java/sparta/com/sappun/domain/reportComment/repository/ReportCommentRepositoryTest.java
+++ b/src/test/java/sparta/com/sappun/domain/reportComment/repository/ReportCommentRepositoryTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 import sparta.com.sappun.domain.board.repository.BoardRepository;
+import sparta.com.sappun.domain.comment.entity.Comment;
 import sparta.com.sappun.domain.comment.repository.CommentRepository;
 import sparta.com.sappun.domain.reportComment.entity.ReportComment;
 import sparta.com.sappun.domain.user.entity.User;
@@ -106,5 +107,38 @@ class ReportCommentRepositoryTest implements ReportCommentTest {
 
         // then
         assertNotNull(result);
+    }
+
+    @Test
+    @DisplayName("댓글 신고 selectReportCommentByUser 테스트")
+    void selectReportCommentByUserTest() {
+        // given
+        User user = userRepository.save(TEST_USER);
+        boardRepository.save(TEST_BOARD);
+        commentRepository.save(TEST_COMMENT);
+        ReportComment reportComment = reportCommentRepository.save(REPORT_COMMENT);
+
+        // when
+        List<ReportComment> reportCommentList = reportCommentRepository.selectReportCommentByUser(user);
+
+        // then
+        assertEquals(reportCommentList.get(0), reportComment);
+    }
+
+    @Test
+    @DisplayName("댓글 신고 deleteAll 테스트")
+    public void deleteAllTest() {
+        // given
+        User user = userRepository.save(TEST_USER);
+        boardRepository.save(TEST_BOARD);
+        Comment comment = commentRepository.save(TEST_COMMENT);
+        ReportComment reportComment = reportCommentRepository.save(REPORT_COMMENT);
+
+        // when
+        reportCommentRepository.deleteAll(List.of(reportComment));
+        boolean isExist = reportCommentRepository.existsReportCommentByCommentAndUser(comment, user);
+
+        // then
+        assertFalse(isExist);
     }
 }

--- a/src/test/java/sparta/com/sappun/domain/user/service/UserServiceTest.java
+++ b/src/test/java/sparta/com/sappun/domain/user/service/UserServiceTest.java
@@ -7,8 +7,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.IMAGE_JPEG_VALUE;
 import static sparta.com.sappun.global.response.ResultCode.*;
+import static sparta.com.sappun.test.LikeBoardTest.TEST_LIKE_BOARD;
+import static sparta.com.sappun.test.LikeCommentTest.TEST_LIKE_COMMENT;
+import static sparta.com.sappun.test.ReportBoardTest.REPORT_BOARD;
+import static sparta.com.sappun.test.ReportCommentTest.REPORT_COMMENT;
 
 import java.io.IOException;
+import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,6 +29,12 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
+import sparta.com.sappun.domain.board.repository.BoardRepository;
+import sparta.com.sappun.domain.comment.repository.CommentRepository;
+import sparta.com.sappun.domain.likeBoard.repository.LikeBoardRepository;
+import sparta.com.sappun.domain.likeComment.repository.LikeCommentRepository;
+import sparta.com.sappun.domain.reportBoard.repository.ReportBoardRepository;
+import sparta.com.sappun.domain.reportComment.repository.ReportCommentRepository;
 import sparta.com.sappun.domain.user.dto.request.*;
 import sparta.com.sappun.domain.user.dto.response.*;
 import sparta.com.sappun.domain.user.entity.Role;
@@ -36,6 +47,12 @@ import sparta.com.sappun.test.UserTest;
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest implements UserTest {
     @Mock UserRepository userRepository;
+    @Mock ReportBoardRepository reportBoardRepository;
+    @Mock ReportCommentRepository reportCommentRepository;
+    @Mock LikeBoardRepository likeBoardRepository;
+    @Mock LikeCommentRepository likeCommentRepository;
+    @Mock BoardRepository boardRepository;
+    @Mock CommentRepository commentRepository;
 
     @Mock PasswordEncoder passwordEncoder;
 
@@ -163,6 +180,12 @@ class UserServiceTest implements UserTest {
     @DisplayName("deleteUser 테스트")
     void deleteUserTest() {
         // given
+        when(reportBoardRepository.selectReportBoardByUser(any())).thenReturn(List.of(REPORT_BOARD));
+        when(reportCommentRepository.selectReportCommentByUser(any()))
+                .thenReturn(List.of(REPORT_COMMENT));
+        when(likeBoardRepository.selectLikeBoardByUser(any())).thenReturn(List.of(TEST_LIKE_BOARD));
+        when(likeCommentRepository.selectLikeCommentByUser(any()))
+                .thenReturn(List.of(TEST_LIKE_COMMENT));
         when(userRepository.findById(any())).thenReturn(TEST_USER);
 
         // when

--- a/src/test/java/sparta/com/sappun/test/BoardTest.java
+++ b/src/test/java/sparta/com/sappun/test/BoardTest.java
@@ -16,8 +16,8 @@ public interface BoardTest extends UserTest {
     List<String> TEST_STOPOVER = List.of("TEST1", "TEST2", "TEST3", "TEST4", "TEST5");
     RegionEnum TEST_REGION1 = RegionEnum.REGION1;
 
-    Integer TEST_LIKECOUNT = 0;
-    Integer TEST_REPORTCOUNT = 0;
+    Integer TEST_LIKE_COUNT = 0;
+    Integer TEST_REPORT_COUNT = 0;
 
     Board TEST_BOARD =
             Board.builder()
@@ -29,8 +29,8 @@ public interface BoardTest extends UserTest {
                     .destination(TEST_DESTINATION)
                     .stopover(TEST_STOPOVER)
                     .region(TEST_REGION1)
-                    .likeCount(TEST_LIKECOUNT)
-                    .reportCount(TEST_REPORTCOUNT)
+                    .likeCount(TEST_LIKE_COUNT)
+                    .reportCount(TEST_REPORT_COUNT)
                     .build();
 
     Board TEST_BOARD1 =
@@ -44,7 +44,7 @@ public interface BoardTest extends UserTest {
                     .stopover(TEST_STOPOVER)
                     .region(TEST_REGION1)
                     .likeCount(1)
-                    .reportCount(TEST_REPORTCOUNT)
+                    .reportCount(TEST_REPORT_COUNT)
                     .build();
 
     Board TEST_BOARD2 =
@@ -58,6 +58,6 @@ public interface BoardTest extends UserTest {
                     .stopover(TEST_STOPOVER)
                     .region(TEST_REGION1)
                     .likeCount(2)
-                    .reportCount(TEST_REPORTCOUNT)
+                    .reportCount(TEST_REPORT_COUNT)
                     .build();
 }


### PR DESCRIPTION
## 개요
회원 탈퇴 로직 수정했습니다.

## 작업사항
- 회원 탈퇴 시 회원이 누른 좋아요, 신고 점수 복구하고 좋아요, 신고 삭제
- 회원 탈퇴 전에 게시글, 댓글 삭제
- Repository Test 보완

## 관련 이슈
- close #146 
