### PR TITLE
[#254] Front: 소셜로그인 네이버 HTTPS -> HTTP로 변경

### DIFF
--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -218,7 +218,7 @@
                    target=""><i class="custom-kakao"></i></a>
             </button>
             <button class="sbutton" id="login-naver-btn">
-                <a href="https://nid.naver.com/oauth2.0/authorize?response_type=code&amp;client_id=DkMAKxIfQr40yq4hYpwZ&amp;redirect_uri=https://43.203.41.214:8080/api/users/naver/callback&amp;state=test"
+                <a href="https://nid.naver.com/oauth2.0/authorize?response_type=code&amp;client_id=DkMAKxIfQr40yq4hYpwZ&amp;redirect_uri=http://43.203.41.214:8080/api/users/naver/callback&amp;state=test"
                    target=""><i class="custom-naver"></i></a>
             </button>
         </div>


### PR DESCRIPTION
## 개요
소셜로그인 네이버 HTTPS -> HTTP로 변경

## 작업사항
- 소셜로그인 네이버 HTTPS -> HTTP로 변경

## 관련 이슈
- close #254 
