### PR TITLE
[#318] feat: 전체 게시글 조회에서 신고누적 5회 이상 조회대상에서 제외

### DIFF
--- a/src/main/java/sparta/com/sappun/domain/board/repository/BoardRepository.java
+++ b/src/main/java/sparta/com/sappun/domain/board/repository/BoardRepository.java
@@ -23,7 +23,7 @@ public interface BoardRepository {
     @Query("SELECT b FROM Board b WHERE b.user.id = :userId")
     Page<Board> findAllUserBoardByUserId(@Param("userId") Long userId, Pageable pageable);
 
-    Page<Board> findAll(Pageable pageable);
+    Page<Board> findAllByReportCountLessThan(int reportCount, Pageable pageable);
 
     List<Board> findTop3ByReportCountLessThanOrderByLikeCountDesc(int reportCount);
 

--- a/src/main/java/sparta/com/sappun/domain/board/service/BoardService.java
+++ b/src/main/java/sparta/com/sappun/domain/board/service/BoardService.java
@@ -62,7 +62,7 @@ public class BoardService {
         Sort sort = Sort.by(direction, sortBy);
         Pageable pageable = PageRequest.of(page, size, sort);
 
-        return boardRepository.findAll(pageable).map(BoardServiceMapper.INSTANCE::toBoardToListGetRes);
+        return boardRepository.findAllByReportCountLessThan(REPORT_HIDDEN_COUNT,pageable).map(BoardServiceMapper.INSTANCE::toBoardToListGetRes);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/sparta/com/sappun/domain/board/service/BoardService.java
+++ b/src/main/java/sparta/com/sappun/domain/board/service/BoardService.java
@@ -62,7 +62,9 @@ public class BoardService {
         Sort sort = Sort.by(direction, sortBy);
         Pageable pageable = PageRequest.of(page, size, sort);
 
-        return boardRepository.findAllByReportCountLessThan(REPORT_HIDDEN_COUNT,pageable).map(BoardServiceMapper.INSTANCE::toBoardToListGetRes);
+        return boardRepository
+                .findAllByReportCountLessThan(REPORT_HIDDEN_COUNT, pageable)
+                .map(BoardServiceMapper.INSTANCE::toBoardToListGetRes);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 개요
전체게시글 조회 시 신고횟수가 5회 이상이여도 조회되는 문제

## 작업사항
- 전체 게시글 조회에서 신고누적 5회 이상 조회대상에서 제외

## 관련 이슈
- close #318 
