### PR TITLE
[#342] Front: 전체 조회 페이지 및 지역 조회 페이지 상단 타이틀 적용

### DIFF
--- a/src/main/resources/templates/allBoardPage.html
+++ b/src/main/resources/templates/allBoardPage.html
@@ -110,7 +110,7 @@
         }
 
         .gallery-container {
-            width: 80%;
+            width: 63%;
             margin-left: auto;
             margin-right: auto;
             margin-top: 20px;
@@ -118,11 +118,13 @@
             flex-wrap: wrap;
             text-align: center;
             justify-content: center;
-            gap: 20px 50px;
+            gap: 20px 30px;
+            flex-direction: row;
+            align-items: center;
         }
 
         .gallery-item {
-            width: calc((70% - 0px) / 4); /* Calculate width with 4 items and 3 gaps between them */
+            width: 275px;
             height: 380px;
             border: 1px solid deeppink;
             border-radius: 25px;
@@ -185,8 +187,8 @@
         }
 
         .rank-image {
-          width: 50px;
-          height: 50px;
+            width: 50px;
+            height: 50px;
         }
 
         #sidebar {
@@ -252,19 +254,21 @@
         #mainLogoImage {
             cursor: pointer;
         }
+
         .btn-style {
             font-family: 'Pretendard-400';
-            width: 65%;
-            margin: 0 auto 30px auto;
+            width: 50%;
+            margin: auto;
             display: flex;
             flex-direction: row;
             justify-content: flex-end;
+            align-items: center;
         }
 
         .btn-style button {
             font-family: 'Pretendard-400';
             margin-left: 10px;
-            width: 8%;
+            width: 15%;
             background-color: white;
             color: black;
             border: 1px solid pink;
@@ -277,6 +281,26 @@
             /* 마우스를 버튼 위에 올렸을 때의 스타일 변경 */
             background-color: pink;
         }
+
+        .page-title {
+            width: 63%;
+            height: 50px;
+            margin: 0 auto;
+            display: flex;
+            flex-direction: row;
+        }
+
+        .page-title1 {
+            font-family: 'yg-jalnan';
+            font-size: 30px;
+            width: 50%;
+            margin: 0 auto;
+            display: flex;
+            flex-direction: row;
+            text-align: center;
+            align-items: center;
+        }
+
     </style>
 </head>
 <body>
@@ -312,23 +336,27 @@
         <div class="btn-write">
             <div th:if="${user != null}" class="rank">
                 <span th:if="${user.score < 0}">
-                    <img th:src="@{https://sappun-walk.s3.ap-northeast-2.amazonaws.com/image/Warned.png}" alt="rank-image"
+                    <img th:src="@{https://sappun-walk.s3.ap-northeast-2.amazonaws.com/image/Warned.png}"
+                         alt="rank-image"
                          class="rank-image">
                 </span>
                 <span th:if="${user.score >= 0 and user.score <= 300}">
-                    <img th:src="@{https://sappun-walk.s3.ap-northeast-2.amazonaws.com/image/Bronze.png}" alt="rank-image"
+                    <img th:src="@{https://sappun-walk.s3.ap-northeast-2.amazonaws.com/image/Bronze.png}"
+                         alt="rank-image"
                          class="rank-image">
                 </span>
                 <span th:if="${user.score > 300 and user.score <= 700}">
-                    <img th:src="@{https://sappun-walk.s3.ap-northeast-2.amazonaws.com/image/Silver.png}" alt="rank-image"
-                        class="rank-image">
+                    <img th:src="@{https://sappun-walk.s3.ap-northeast-2.amazonaws.com/image/Silver.png}"
+                         alt="rank-image"
+                         class="rank-image">
                 </span>
                 <span th:if="${user.score > 700 and user.score <= 1200}">
                     <img th:src="@{https://sappun-walk.s3.ap-northeast-2.amazonaws.com/image/Gold.png}" alt="rank-image"
-                        class="rank-image">
+                         class="rank-image">
                 </span>
                 <span th:if="${user.score > 1200}">
-                    <img th:src="@{https://sappun-walk.s3.ap-northeast-2.amazonaws.com/image/Platinum.png}" alt="rank-image"
+                    <img th:src="@{https://sappun-walk.s3.ap-northeast-2.amazonaws.com/image/Platinum.png}"
+                         alt="rank-image"
                          class="rank-image">
                 </span>
             </div>
@@ -358,13 +386,16 @@
         </div>
     </div>
 </div>
-<div class="btn-style">
-    <button class="buttons1" type="button" onclick="changeSortAndPage('createdAt')">
-        최신순
-    </button>
-    <button class="buttons1" type="button" onclick="changeSortAndPage('likeCount')">
-        좋아요순
-    </button>
+<div class="page-title">
+    <h3 class="page-title1">전체 게시글</h3>
+    <div class="btn-style">
+        <button type="button" onclick="changeSortAndPage('createdAt')">
+            최신순
+        </button>
+        <button type="button" onclick="changeSortAndPage('likeCount')">
+            좋아요순
+        </button>
+    </div>
 </div>
 <div class="gallery-container">
     <div class="gallery-item" th:each="allboard : ${responseDto.content}" th:id="${'allboard-' + allboard.id}"

--- a/src/main/resources/templates/regionPage.html
+++ b/src/main/resources/templates/regionPage.html
@@ -109,7 +109,7 @@
         }
 
         .gallery-container {
-            width: 80%;
+            width: 63%;
             margin-left: auto;
             margin-right: auto;
             margin-top: 20px;
@@ -117,11 +117,13 @@
             flex-wrap: wrap;
             text-align: center;
             justify-content: center;
-            gap: 20px 50px;
+            gap: 20px 30px;
+            flex-direction: row;
+            align-items: center;
         }
 
         .gallery-item {
-            width: calc((70% - 0px) / 4); /* Calculate width with 4 items and 3 gaps between them */
+            width: 275px;
             height: 380px;
             border: 1px solid deeppink;
             border-radius: 25px;
@@ -184,8 +186,8 @@
         }
 
         .rank-image {
-          width: 50px;
-          height: 50px;
+            width: 50px;
+            height: 50px;
         }
 
         #sidebar {
@@ -236,35 +238,24 @@
             visibility: hidden;
         }
 
-        .view-div {
-            margin-left: auto;
-            margin-right: 18%;
-            display: flex;
-            flex-direction: row-reverse;
-            gap: 10px;
-        }
-
-        .view-div1 {
-            font-family: 'Pretendard-400';
-        }
-
         #mainLogoImage {
             cursor: pointer;
         }
 
         .btn-style {
             font-family: 'Pretendard-400';
-            width: 65%;
-            margin: 0 auto 30px auto;
+            width: 50%;
+            margin: auto;
             display: flex;
             flex-direction: row;
             justify-content: flex-end;
+            align-items: center;
         }
 
         .btn-style button {
             font-family: 'Pretendard-400';
             margin-left: 10px;
-            width: 8%;
+            width: 15%;
             background-color: white;
             color: black;
             border: 1px solid pink;
@@ -276,6 +267,25 @@
         .btn-style button:hover {
             /* 마우스를 버튼 위에 올렸을 때의 스타일 변경 */
             background-color: pink;
+        }
+
+        .page-title {
+            width: 63%;
+            height: 50px;
+            margin: 0 auto;
+            display: flex;
+            flex-direction: row;
+        }
+
+        .page-title1 {
+            font-family: 'yg-jalnan';
+            font-size: 30px;
+            width: 50%;
+            margin: 0 auto;
+            display: flex;
+            flex-direction: row;
+            text-align: center;
+            align-items: center;
         }
     </style>
 </head>
@@ -313,15 +323,18 @@
         <div class="btn-write">
             <div th:if="${user != null}" class="rank">
                 <span th:if="${user.score < 0}">
-                    <img th:src="@{https://sappun-walk.s3.ap-northeast-2.amazonaws.com/image/Warned.png}" alt="rank-image"
+                    <img th:src="@{https://sappun-walk.s3.ap-northeast-2.amazonaws.com/image/Warned.png}"
+                         alt="rank-image"
                          class="rank-image">
                 </span>
                 <span th:if="${user.score >= 0 and user.score <= 300}">
-                    <img th:src="@{https://sappun-walk.s3.ap-northeast-2.amazonaws.com/image/Bronze.png}" alt="rank-image"
+                    <img th:src="@{https://sappun-walk.s3.ap-northeast-2.amazonaws.com/image/Bronze.png}"
+                         alt="rank-image"
                          class="rank-image">
                 </span>
                 <span th:if="${user.score > 300 and user.score <= 700}">
-                    <img th:src="@{https://sappun-walk.s3.ap-northeast-2.amazonaws.com/image/Silver.png}" alt="rank-image"
+                    <img th:src="@{https://sappun-walk.s3.ap-northeast-2.amazonaws.com/image/Silver.png}"
+                         alt="rank-image"
                          class="rank-image">
                 </span>
                 <span th:if="${user.score > 700 and user.score <= 1200}">
@@ -329,7 +342,8 @@
                          class="rank-image">
                 </span>
                 <span th:if="${user.score > 1200}">
-                    <img th:src="@{https://sappun-walk.s3.ap-northeast-2.amazonaws.com/image/Platinum.png}" alt="rank-image"
+                    <img th:src="@{https://sappun-walk.s3.ap-northeast-2.amazonaws.com/image/Platinum.png}"
+                         alt="rank-image"
                          class="rank-image">
                 </span>
             </div>
@@ -359,14 +373,18 @@
         </div>
     </div>
 
-    <div class="btn-style">
-        <button class="buttons1" type="button" onclick="changeSortAndPage('createdAt')">
-            최신순
-        </button>
-        <button class="buttons1" type="button" onclick="changeSortAndPage('likeCount')">
-            좋아요순
-        </button>
+    <div class="page-title">
+        <h3 class="page-title1" th:text="${region.getRegion()}"></h3>
+        <div class="btn-style">
+            <button class="buttons1" type="button" onclick="changeSortAndPage('createdAt')">
+                최신순
+            </button>
+            <button class="buttons1" type="button" onclick="changeSortAndPage('likeCount')">
+                좋아요순
+            </button>
+        </div>
     </div>
+
 
     <div class="gallery-container">
         <div class="gallery-item" th:each="board : ${responseDto.content}" th:id="${'board-' + board.id}"


### PR DESCRIPTION
## 개요
전체 조회 페이지 및 지역 조회 페이지 상단 타이틀 적용

## 작업사항
- 전체 조회 페이지 및 지역 조회 페이지 상단 타이틀 적용
- 게시글 컨테이너 수정_ 화면 비율작아졌을시 카드가 하단으로 이동되게 변경

## 관련 이슈
-  close #342 
