### PR TITLE
#352 페이지 이동버튼 동적으로 5개 제한 기능 구현 / 전체,지역,유저 게시글

### DIFF
--- a/src/main/resources/templates/allBoardPage.html
+++ b/src/main/resources/templates/allBoardPage.html
@@ -416,17 +416,29 @@
 
 
 <div class="page-num" th:with="start=${(responseDto.number/maxPage)*maxPage + 1},
-              end=(${(responseDto.totalPages == 0) ? 1 : (start + (maxPage - 1) < responseDto.totalPages ? start + (maxPage - 1) : responseDto.totalPages)})">
+end=(${(responseDto.totalPages == 0) ? 1 : (start + (maxPage - 1) < responseDto.totalPages ? start + (maxPage - 1) : responseDto.totalPages)}),
+currentPage=${responseDto.number + 1}">
+
+    <!-- 현재 페이지를 중심으로 앞뒤로 2개의 페이지만 표시 -->
+    <!-- 첫 페이지로 이동 -->
     <ul class="page-nation">
-        <li class="li1" th:each="pageNum: ${#numbers.sequence(start, end)}">
+        <li class="li1" th:if="${currentPage > 1}">
+            <a href="#" th:data-page="1" onclick="changeAllBoardPage(this)">
+                <span th:text="'<<'"></span>
+            </a>
+        </li>
+        <li class="li1" th:each="pageNum: ${#numbers.sequence(currentPage - 2, currentPage + 2 < end ? currentPage + 2 : end)}" th:if="${pageNum >= start}">
             <a href="#" th:data-page="${pageNum}" onclick="changeAllBoardPage(this)">
                 <span th:text="${pageNum}"></span>
             </a>
         </li>
+        <!-- 다음 페이지로 이동 -->
+        <li class="li1" th:if="${currentPage < end}">
+            <a href="#" th:data-page="${end}" onclick="changeAllBoardPage(this)">
+                <span th:text="'>>'"></span>
+            </a>
+        </li>
     </ul>
-    <a href="#" th:data-page="${pageNum}" onclick="changeAllBoardPage(this)">
-        <span th:text="${pageNum}"></span>
-    </a>
 </div>
 <script>
     const host = 'http://' + window.location.host;

--- a/src/main/resources/templates/allBoardPage.html
+++ b/src/main/resources/templates/allBoardPage.html
@@ -418,7 +418,6 @@
 <div class="page-num" th:with="start=${(responseDto.number/maxPage)*maxPage + 1},
 end=(${(responseDto.totalPages == 0) ? 1 : (start + (maxPage - 1) < responseDto.totalPages ? start + (maxPage - 1) : responseDto.totalPages)}),
 currentPage=${responseDto.number + 1}">
-
     <!-- 현재 페이지를 중심으로 앞뒤로 2개의 페이지만 표시 -->
     <!-- 첫 페이지로 이동 -->
     <ul class="page-nation">

--- a/src/main/resources/templates/regionPage.html
+++ b/src/main/resources/templates/regionPage.html
@@ -404,7 +404,6 @@
 <div class="page-num" th:with="start=${(responseDto.number/maxPage)*maxPage + 1},
               end=(${(responseDto.totalPages == 0) ? 1 : (start + (maxPage - 1) < responseDto.totalPages ? start + (maxPage - 1) : responseDto.totalPages)}),
               currentPage=${responseDto.number + 1}">
-
     <!-- 현재 페이지를 중심으로 앞뒤로 2개의 페이지만 표시 -->
     <ul class="page-nation">
         <li class="li1" th:if="${currentPage > 1}">

--- a/src/main/resources/templates/regionPage.html
+++ b/src/main/resources/templates/regionPage.html
@@ -402,18 +402,30 @@
 </div>
 
 <div class="page-num" th:with="start=${(responseDto.number/maxPage)*maxPage + 1},
-              end=(${(responseDto.totalPages == 0) ? 1 : (start + (maxPage - 1) < responseDto.totalPages ? start + (maxPage - 1) : responseDto.totalPages)})">
+              end=(${(responseDto.totalPages == 0) ? 1 : (start + (maxPage - 1) < responseDto.totalPages ? start + (maxPage - 1) : responseDto.totalPages)}),
+              currentPage=${responseDto.number + 1}">
+
+    <!-- 현재 페이지를 중심으로 앞뒤로 2개의 페이지만 표시 -->
     <ul class="page-nation">
-        <li class="li1" th:each="pageNum: ${#numbers.sequence(start, end)}">
+        <li class="li1" th:if="${currentPage > 1}">
+            <!-- 처음 페이지로 이동 -->
+            <a href="#" th:data-region="${region}" th:data-page="1" onclick="changeRegionAndPage(this)">
+                <span th:text="'<<'"></span>
+            </a>
+        </li>
+        <li class="li1" th:each="pageNum: ${#numbers.sequence(currentPage - 2, currentPage + 2 < end ? currentPage + 2 : end)}" th:if="${pageNum >= start}">
             <a href="#" th:data-region="${region}" th:data-page="${pageNum}" onclick="changeRegionAndPage(this)">
                 <span th:text="${pageNum}"></span>
             </a>
         </li>
+        <li class="li1" th:if="${currentPage < end}">
+            <a href="#" th:data-region="${region}" th:data-page="${end}" onclick="changeRegionAndPage(this)">
+                <span th:text="'>>'"></span>
+            </a>
+        </li>
     </ul>
-    <a href="#" th:data-region="${region}" th:data-page="${pageNum}" onclick="changeRegionAndPage(this)">
-        <span th:text="${pageNum}"></span>
-    </a>
 </div>
+
 <script>
     const host = 'http://' + window.location.host;
     const loginPage = '/api/users/login';

--- a/src/main/resources/templates/userBoardPage.html
+++ b/src/main/resources/templates/userBoardPage.html
@@ -373,17 +373,29 @@
 </div>
 
 <div class="page-num" th:with="start=${(responseDto.number/maxPage)*maxPage + 1},
-              end=(${(responseDto.totalPages == 0) ? 1 : (start + (maxPage - 1) < responseDto.totalPages ? start + (maxPage - 1) : responseDto.totalPages)})">
+end=(${(responseDto.totalPages == 0) ? 1 : (start + (maxPage - 1) < responseDto.totalPages ? start + (maxPage - 1) : responseDto.totalPages)}),
+currentPage=${responseDto.number + 1}">
+
+    <!-- 현재 페이지를 중심으로 앞뒤로 2개의 페이지만 표시 -->
+    <!-- 첫 페이지로 이동 -->
     <ul class="page-nation">
-        <li class="li1" th:each="pageNum: ${#numbers.sequence(start, end)}">
+        <li class="li1" th:if="${currentPage > 1}">
+            <a href="#" th:data-page="1" onclick="changeUserBoardPage(this)">
+                <span th:text="'<<'"></span>
+            </a>
+        </li>
+        <li class="li1" th:each="pageNum: ${#numbers.sequence(currentPage - 2, currentPage + 2 < end ? currentPage + 2 : end)}" th:if="${pageNum >= start}">
             <a href="#" th:data-page="${pageNum}" onclick="changeUserBoardPage(this)">
                 <span th:text="${pageNum}"></span>
             </a>
         </li>
+        <!-- 다음 페이지로 이동 -->
+        <li class="li1" th:if="${currentPage < end}">
+            <a href="#" th:data-page="${end}" onclick="changeUserBoardPage(this)">
+                <span th:text="'>>'"></span>
+            </a>
+        </li>
     </ul>
-    <a href="#" th:data-page="${pageNum}" onclick="changeUserBoardPage(this)">
-        <span th:text="${pageNum}"></span>
-    </a>
 </div>
 <script>
     const host = 'http://' + window.location.host;

--- a/src/main/resources/templates/userBoardPage.html
+++ b/src/main/resources/templates/userBoardPage.html
@@ -375,7 +375,6 @@
 <div class="page-num" th:with="start=${(responseDto.number/maxPage)*maxPage + 1},
 end=(${(responseDto.totalPages == 0) ? 1 : (start + (maxPage - 1) < responseDto.totalPages ? start + (maxPage - 1) : responseDto.totalPages)}),
 currentPage=${responseDto.number + 1}">
-
     <!-- 현재 페이지를 중심으로 앞뒤로 2개의 페이지만 표시 -->
     <!-- 첫 페이지로 이동 -->
     <ul class="page-nation">


### PR DESCRIPTION
## 개요
페이지 이동버튼 동적으로 5개 제한 기능 구현 / 전체,지역,유저 게시글

## 작업사항
- 페이지 이동버튼 동적으로 5개 제한 기능 구현 / 전체,지역,유저 게시글
- 첫페이지와 마지막 페이지로 이동하는 버튼 구현

## 관련 이슈
- close #352 
