### PR TITLE
Jacoco 적용 범위 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,4 +674,4 @@ MDY3OTM5NDUsImlhdCI6MTcwNjc5MDM0NX0.mzW4oBI0gIx3hHELmVYWZWjLcf8p_8EAaYeq0hebcKU
 
 ### Jacoco 테스트 문서
 
-<img width="616" alt="jacoco" src="https://github.com/Sappun-Walk/Sappun/assets/99391320/de730c22-8621-4709-8f3e-fcdd31f02417">
+<img width="616" alt="jacoco" src="src/main/resources/static/images/jacoco.png">

--- a/build.gradle
+++ b/build.gradle
@@ -122,3 +122,19 @@ sourceSets {
 clean.doLast {
     file(querydslDir).deleteDir()
 }
+
+test {
+    finalizedBy jacocoTestReport // 테스트 실행 후 JaCoCo 보고서 생성
+}
+
+jacocoTestReport {
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: ['sparta/com/sappun/domain/board/dto/**', 'sparta/com/sappun/domain/comment/dto/**', 'sparta/com/sappun/domain/likeBoard/dto/**',
+                                        'sparta/com/sappun/domain/likeComment/dto/**', 'sparta/com/sappun/domain/reportBoard/dto/**', 'sparta/com/sappun/domain/reportComment/dto/**', 'sparta/com/sappun/domain/user/dto/**',
+                                        'sparta/com/sappun/global/config/**', 'sparta/com/sappun/global/jpa/**',
+                                        'sparta/com/sappun/global/redis/RedisConfig.class', 'sparta/com/sappun/global/security/WebSecurityConfig.class', 'sparta/com/sappun/infra/s3/S3Config.class'])
+        }))
+    }
+}


### PR DESCRIPTION
## 개요
Jacoco 적용 범위에 dto, config 파일은 제외하도록 수정

## 작업사항
- Jacoco 적용 범위 수정
- readme 수정

## 관련 이슈
- close #429 
